### PR TITLE
Document updates

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -65,8 +65,8 @@ Develop and create pull-request (PR)
 
 5. [If applicable] Create new example notebook.
     
-    * Store notebook in ``./docs/notebooks/<tutorial.ipynb>``.
-    * Index notebook in ``./docs/tutorial.rst``
+    * Store notebook in ``./docs/source/notebooks/<tutorial.ipynb>``.
+    * Index notebook in ``./docs/source/tutorial.rst``
 
 6. [If applicable] Add new dependencies in ``./setup.cfg``
 

--- a/docs/source/notebooks/ex_intro.ipynb
+++ b/docs/source/notebooks/ex_intro.ipynb
@@ -5,42 +5,137 @@
    "id": "6376980d-bbaa-44d1-9d3f-938c45ed2f90",
    "metadata": {},
    "source": [
-    "# Example from the Tutorial\n",
+    "# Introductory Tutorial\n",
     "\n",
-    "This notebook executes the example from the Introductory Tutorial"
+    "This is a short introduction on how to use `pystra`. The tutorial above is also available on GitHub under ``example.py``."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cce7070e-a7e3-4c3c-b005-1e1483d4aab4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## An example reliability model\n",
+    "Consider the following random variables:\n",
+    "\n",
+    "\n",
+    "$$\\begin{align}\n",
+    "X_1 &\\sim \\text{Logormal}(500,100)\\\\\n",
+    "X_2 &\\sim \\text{Normal}(2000,400) \\label{random_variables}\\tag{1}\\\\\n",
+    "X_3 &\\sim \\text{Uniform}(5,0.5)\n",
+    "\\end{align}$$\n",
+    "\n",
+    "Additionally those variables are related to each other. Therefore the\n",
+    "correlation matrix ${\\bf C}$ is given:\n",
+    "\n",
+    "$$\n",
+    "            \\begin{align}\n",
+    "            {\\bf C} = \n",
+    "            \\begin{pmatrix}\n",
+    "            1.0 & 0.3 & 0.2\\\\\n",
+    "            0.3 & 1.0 & 0.2 \\label{correlation_matrix}\\tag{2}\\\\\n",
+    "            0.2 & 0.2 & 1.0\n",
+    "            \\end{pmatrix}\n",
+    "            \\end{align}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa544f0f-3041-4284-b62f-537985b0d4ad",
+   "metadata": {},
+   "source": [
+    "Now, we like to compute the reliability index $\\beta$ and the failure\n",
+    "probability $P_f$, by given limit state function $g(\\gamma, X_1,X_2,X_3)$:\n",
+    "\n",
+    "$$\n",
+    "            g(\\gamma, X_1,X_2,X_3) = \\gamma - \\frac{X_2}{1000 \\cdot X_3} - \n",
+    "            \\left( \\frac{X_1}{200 \\cdot X_3} \\right)^2\n",
+    "            \\label{limit_state_function}\\tag{3}\n",
+    "$$ \n",
+    "\n",
+    "where $\\gamma$ is a real constant. For this example, let $\\gamma = 1$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "389ecbcb-22c0-4d16-b140-305fc31aeb05",
+   "metadata": {},
+   "source": [
+    "## Establish the model\n",
+    "Before we start with the modeling, we have to import the `pystra`\n",
+    "package and other relevant packages."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "614cdc71-3111-489c-882a-91707c27debb",
+   "execution_count": 1,
+   "id": "4eb22bb1-4734-4bc1-94a3-00110b3e1469",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pystra as pr\n",
+    "import pystra as ra\n",
     "import numpy as np"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "95ae2a48-aa69-435b-ab7b-099c9f30f49c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Two ways to define the limit state function are available:\n",
+    "+ Direct in the `main` code,\n",
+    "+ as a separate `function`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84d7541-5e5a-4b3b-887a-199b9d81a00c",
    "metadata": {},
    "source": [
-    "## Establish the model"
+    "In the first case the input will look like:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "id": "f7644250-396a-4640-a31e-737507ab5dc1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def example_limitstatefunction(r, X1, X2, X3):\n",
+    "# Define limit state function\n",
+    "# - case 1: define directly\n",
+    "limit_state = ra.LimitState(lambda g,X1,X2,X3: g - X2*(1000*X3)**(-1) - (X1*(200*X3)**(-1))**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a52c03a0-d8ec-483d-aa8d-ffdbf9f700bd",
+   "metadata": {},
+   "source": [
+    "and in the second case like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e0daae66-9f9f-4bb2-a669-513ef40c3891",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define limit state function\n",
+    "# - case 2: use predefined function\n",
+    "def example_limitstatefunction(g, X1, X2, X3):\n",
     "    \"\"\"\n",
     "    example limit state function\n",
     "    \"\"\"\n",
-    "    return r - X2 * (1000 * X3) ** (-1) - (X1 * (200 * X3) ** (-1)) ** 2"
+    "    return g - X2 * (1000 * X3) ** (-1) - (X1 * (200 * X3) ** (-1)) ** 2\n",
+    "\n",
+    "limit_state = ra.LimitState(example_limitstatefunction)"
    ]
   },
   {
@@ -48,17 +143,26 @@
    "id": "7896af68-b68f-4f53-a06b-427044cfbb1d",
    "metadata": {},
    "source": [
-    "Define limit state function"
+    "Notice, here the function `example_limitstatefunction` has be defined in advance as a separate function. This case can be useful if the limit state function is quiet complex\n",
+    "or need more then one line to define it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fa40efa-0126-4379-9a84-6b80ef20d202",
+   "metadata": {},
+   "source": [
+    "In the next step the stochastic model has to be initialized"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "ed4f574a-8fb8-448b-b05e-41060f56a6e7",
+   "execution_count": 4,
+   "id": "6d3ec4cc-acb5-4dc6-8928-6715dd18d0e1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "limit_state = pr.LimitState(example_limitstatefunction)"
+    "stochastic_model = ra.StochasticModel()"
    ]
   },
   {
@@ -66,17 +170,134 @@
    "id": "f2d0fed6-678c-47dd-9672-b60440c1f9c4",
    "metadata": {},
    "source": [
-    "Set some options - here we suppress the console output"
+    "and the random variables have to be assigned. To define the random\n",
+    "variables from ([1](#mjx-eqn-eq1)) we can use following syntax:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
+   "id": "723cd6e4-4912-4495-8d27-d052a17a9536",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define random variables\n",
+    "stochastic_model.addVariable(ra.Lognormal(\"X1\", 500, 100))\n",
+    "stochastic_model.addVariable(ra.Normal(\"X2\", 2000, 400))\n",
+    "stochastic_model.addVariable(ra.Uniform(\"X3\", 5, 0.5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd74d2ac-9816-4486-9e85-40d258fc7f8d",
+   "metadata": {},
+   "source": [
+    "The first parameter is the name of the random variable. The name has to be a string and match the arguments in the limit state function, so the input looks like `\"X3\"`.\n",
+    "\n",
+    "By default, the next to values are the first and second moment of the distribution, here mean and standard deviation. If mean and standard deviation unknown but the distribution parameter known, then the `input_type` has to be changed.\n",
+    "\n",
+    "For example random variable $X_3$ is uniform distributed. Above we assume that $X_3$ is defined by mean and standard deviation. But we can describe the distribution with the parameter $a$ and $b$. In this case the code will look like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b2f32aaf-0428-43d0-afcb-e1bb68d16e84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X3 = ra.Uniform('X3',4.133974596215562, 5.866025403784438, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "286e7fad-0b3c-48ed-98c5-6f2738dc509c",
+   "metadata": {},
+   "source": [
+    "to get the same results as before. To see which parameters are needed and in which order the must insert, refer to the Distributions API.\n",
+    "\n",
+    "If the nominal value, bias, and coefficient of variation are instead known, then the random variable can be instantiated following this example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a23973bc-d620-4be6-8bd4-14ed7e0478f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X2 = ra.Normal('X2',*500*1.00*np.array([1, 0.2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80701034-6b6a-421b-89de-56df495b4f6d",
+   "metadata": {},
+   "source": [
+    "where nominal value is 500, bias is 1.00, and coefficient of variation is 0.2. Notice the initial * character is used to dereference the output array.\n",
+    "\n",
+    "We will also define our constant using `Constant`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "40f200af-576a-4fc6-87dc-7886aa36369e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define constants\n",
+    "stochastic_model.addVariable( ra.Constant('g',1) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebb020e5-1313-4cfa-adb9-23e1297b2d43",
+   "metadata": {},
+   "source": [
+    "To add the correlation matrix to our model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "683e3837-ffa5-47f1-af25-e2c00fe0d7a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define Correlation Matrix\n",
+    "stochastic_model.setCorrelation( ra.CorrelationMatrix([[1.0, 0.3, 0.2],\n",
+    "                                                       [0.3, 1.0, 0.2],\n",
+    "                                                       [0.2, 0.2, 1.0]]) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9ad2666-047d-4179-860a-cb354141c863",
+   "metadata": {},
+   "source": [
+    "If the variables uncorrelated, you don’t have to add a correlation matrix to the model.\n",
+    "\n",
+    "At this stage our model is complete defined and we can start the analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c11c1bf-0395-4871-ae84-f19b08d9482b",
+   "metadata": {},
+   "source": [
+    "## Reliability Analysis\n",
+    "To change some options, a object must be initialized which stores the customized options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "31ea3f31-71dd-4401-93e6-0f7b7eba87e8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "options = pr.AnalysisOptions()\n",
+    "options = ra.AnalysisOptions()\n",
     "options.setPrintOutput(False)"
    ]
   },
@@ -85,37 +306,26 @@
    "id": "5831c2dc-0c6f-4ee5-b8c9-b636ae36882c",
    "metadata": {},
    "source": [
-    "Create the stochamstic model object"
+    "To store the results from the analysis an object must be initialized\n",
+    "### FORM Analysis\n",
+    "Now the code can be compiled and the FORM analysis will be preformed. In this example we will get following results:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "id": "6d43f515-92ff-40f1-a8ae-399670c1f0d1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "stochastic_model = pr.StochasticModel()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b6a97bd-6672-4e4d-ae76-ebd2d4740229",
-   "metadata": {},
-   "source": [
-    "Define and add random variables to the stochastic model object"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "80e08985-8610-4e2a-ac6a-a687248905ee",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stochastic_model.addVariable(pr.Lognormal(\"X1\", 500, 100))\n",
-    "stochastic_model.addVariable(pr.Normal(\"X2\", 2000, 400))\n",
-    "stochastic_model.addVariable(pr.Uniform(\"X3\", 5, 0.5))"
+    "# initialize analysis obejct\n",
+    "Analysis = ra.Form(\n",
+    "    analysis_options=options,\n",
+    "    stochastic_model=stochastic_model,\n",
+    "    limit_state=limit_state,\n",
+    ")\n",
+    "\n",
+    "Analysis.run() # run analysis"
    ]
   },
   {
@@ -123,17 +333,21 @@
    "id": "c7fd052a-d77b-4dee-a9dc-98b211e8595c",
    "metadata": {},
    "source": [
-    "Define constants that can be part of the stochastic model for ease of argument passing"
+    "If we don’t like to see the results in the terminal the option `setPrintOutput(False)` has set to be `False`. There are also some other options which can be modified.\n",
+    "\n",
+    "To use the results for further calculations, plots etc. the results can get by some getter methods"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "id": "8f2127c1-b206-4e30-94a2-37631c3b7278",
    "metadata": {},
    "outputs": [],
    "source": [
-    "stochastic_model.addVariable(pr.Constant(\"r\", 1))"
+    "# Some single results:\n",
+    "beta = Analysis.getBeta()\n",
+    "failure = Analysis.getFailure()"
    ]
   },
   {
@@ -141,56 +355,13 @@
    "id": "fe2414f6-c4c9-4293-8ade-5c0c3a55cd93",
    "metadata": {},
    "source": [
-    "If the random variables are correlated, then define a correlation matrix, otherwise no correlatin matrix is needed"
+    "There is also the possibility to output more detailed results using `showDetailedOutput()`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "1e9a8ba5-76cb-43a5-afd7-bca32de15289",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stochastic_model.setCorrelation(\n",
-    "    pr.CorrelationMatrix([[1.0, 0.3, 0.2], [0.3, 1.0, 0.2], [0.2, 0.2, 1.0]])\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a0669e68-3d04-41aa-b215-10258a751daa",
-   "metadata": {},
-   "source": [
-    "## FORM Analysis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "af723959-f6ff-4857-b735-da127b69bc62",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "form = pr.Form(\n",
-    "    analysis_options=options,\n",
-    "    stochastic_model=stochastic_model,\n",
-    "    limit_state=limit_state,\n",
-    ")\n",
-    "form.run()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6c1d0808-91c3-453f-b2e8-527707a46328",
-   "metadata": {},
-   "source": [
-    "Show detailed output"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "cb8da34b-64cf-4929-a181-a326fa9cf13c",
+   "execution_count": 13,
+   "id": "a916c429-b03c-4dde-ad49-4efe93524c4f",
    "metadata": {},
    "outputs": [
     {
@@ -209,56 +380,47 @@
       "X1         \t  1.278045 \t   631.504135 \t +0.728414\n",
       "X2         \t  0.407819 \t  2310.352495 \t +0.232354\n",
       "X3         \t -1.129920 \t     4.517374 \t -0.644534\n",
-      "r          \t       --- \t     1.000000 \t       ---\n",
+      "g          \t       --- \t     1.000000 \t       ---\n",
       "======================================================\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "form.showDetailedOutput()"
+    "Analysis.showDetailedOutput()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0669e68-3d04-41aa-b215-10258a751daa",
+   "metadata": {},
+   "source": [
+    "### SORM Analysis"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "480f33e6-e25b-4142-8612-4bf558216b8e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## SORM Analysis\n",
-    "For efficiency, we can pass the FORM results object if it exists, otherwise it will be called automatically."
+    "A Second-Order Reliability Method (SORM) can also be performed, passing in the results of a FORM analysis object if it exists. For efficiency, we can pass the FORM results object if it exists, otherwise it will be called automatically."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "id": "178f2f9a-0ec7-4888-8331-63992e17a4f6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "======================================================\n",
-      "\n",
-      "RESULTS FROM RUNNING SECOND ORDER RELIABILITY METHOD\n",
-      "\n",
-      "Generalized reliability index:  1.848997968430195\n",
-      "Probability of failure:         0.03222905303518171\n",
-      "\n",
-      "Curavture 1: -0.0414313089629377\n",
-      "Curavture 2: 0.36356407339249475\n",
-      "======================================================\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "sorm = pr.Sorm(\n",
+    "sorm = ra.Sorm(\n",
     "    analysis_options=options,\n",
     "    stochastic_model=stochastic_model,\n",
     "    limit_state=limit_state,\n",
-    "    form=form,\n",
+    "    form=Analysis,\n",
     ")\n",
     "sorm.run()"
    ]
@@ -268,12 +430,12 @@
    "id": "a9cf8afd-2d9f-44ed-8cf3-ae82926bbc96",
    "metadata": {},
    "source": [
-    "Detailed output"
+    "Similar to FORM, we can also get more detailed output for diagnostics:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "id": "5aa93de0-c7db-42ea-aac4-30d7d8b32661",
    "metadata": {},
    "outputs": [
@@ -286,21 +448,21 @@
       "FORM/SORM\n",
       "======================================================\n",
       "Pf FORM         \t\t 3.9717297753e-02\n",
-      "Pf SORM Breitung \t\t 3.2229053035e-02\n",
-      "Pf SORM Breitung HR \t 3.1158626160e-02\n",
+      "Pf SORM Breitung \t\t 3.2229053013e-02\n",
+      "Pf SORM Breitung HR \t 3.1158626135e-02\n",
       "Beta_HL         \t\t 1.7539761407\n",
-      "Beta_G Breitung \t\t 1.8489979684\n",
-      "Beta_G Breitung HR \t\t 1.8640317035\n",
+      "Beta_G Breitung \t\t 1.8489979687\n",
+      "Beta_G Breitung HR \t\t 1.8640317038\n",
       "Model Evaluations \t\t 180\n",
       "------------------------------------------------------\n",
-      "Curvature 1: -0.0414313089629377\n",
-      "Curvature 2: 0.36356407339249475\n",
+      "Curvature 1: -0.04143130874014485\n",
+      "Curvature 2: 0.36356407428350895\n",
       "------------------------------------------------------\n",
       "Variable   \t    U_star \t       X_star \t     alpha\n",
       "X1         \t  1.278045 \t   631.504135 \t +0.728414\n",
       "X2         \t  0.407819 \t  2310.352495 \t +0.232354\n",
       "X3         \t -1.129920 \t     4.517374 \t -0.644534\n",
-      "r          \t       --- \t     1.000000 \t       ---\n",
+      "g          \t       --- \t     1.000000 \t       ---\n",
       "======================================================\n",
       "\n"
      ]
@@ -312,20 +474,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9d24d65e-50cb-4ee6-b4f9-7d50168531f8",
+   "metadata": {},
+   "source": [
+    "in which HR refers to the Hohenbichler-Rackwitz modification to Breitung’s formula."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f3c504b2-22d3-4f12-80a8-758251262ddb",
    "metadata": {},
    "source": [
-    "## Distribution Analysis"
+    "### Distribution Analysis"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "id": "6e9d0604-7e5d-4d19-8238-91a4ce3fe13d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "da = pr.DistributionAnalysis(\n",
+    "da = ra.DistributionAnalysis(\n",
     "    analysis_options=options,\n",
     "    stochastic_model=stochastic_model,\n",
     "    limit_state=limit_state,\n",
@@ -338,17 +508,17 @@
    "id": "e6f3a715-779c-4fa7-8994-7d5bfacffda0",
    "metadata": {},
    "source": [
-    "## Crude Monte Carlo Simulation"
+    "### Crude Monte Carlo Simulation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 17,
    "id": "900d7349-9cae-4233-9767-e80be9b4e6c1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmc = pr.CrudeMonteCarlo(\n",
+    "cmc = ra.CrudeMonteCarlo(\n",
     "    analysis_options=options,\n",
     "    stochastic_model=stochastic_model,\n",
     "    limit_state=limit_state,\n",
@@ -361,17 +531,17 @@
    "id": "dcba4e9a-d924-4b23-991d-4ec414bc7b0f",
    "metadata": {},
    "source": [
-    "## Importance Sampling"
+    "### Importance Sampling"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "id": "01836253-ed74-4761-bff4-6b53c351340f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ismc = pr.ImportanceSampling(\n",
+    "ismc = ra.ImportanceSampling(\n",
     "    analysis_options=options,\n",
     "    stochastic_model=stochastic_model,\n",
     "    limit_state=limit_state,\n",
@@ -384,12 +554,12 @@
    "id": "92b37a12-cc3e-45de-be2b-6b5e0625672b",
    "metadata": {},
    "source": [
-    "## Results"
+    "### Results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 19,
    "id": "b47c3a02-d5a8-482c-8bcf-7182235a744a",
    "metadata": {},
    "outputs": [
@@ -397,13 +567,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Beta is 1.7539761407409615, corresponding to a failure probability of [0.0397173]\n"
+      "Beta is 1.7539761407409655, corresponding to a failure probability of [0.0397173]\n"
      ]
     }
    ],
    "source": [
-    "beta = form.getBeta()\n",
-    "failure = form.getFailure()\n",
+    "beta = Analysis.getBeta()\n",
+    "failure = Analysis.getFailure()\n",
     "\n",
     "print(f\"Beta is {beta}, corresponding to a failure probability of {failure}\")"
    ]
@@ -411,9 +581,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pystra",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pystra"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -425,7 +595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -4,10 +4,14 @@
 Tutorials
 *********
 
+These tutorials will guide you through typical Pystra application. Familiarity
+with Python is assumed, so if you are new to Python, books such as [Lutz2007]_
+or [Langtangen2009]_ are the place to start. Plenty of online documentation
+can also be found on the `Python documentation`_ page.
+
 .. toctree::
     :maxdepth: 1
 
-    notebooks/intro
     notebooks/ex_intro
     notebooks/ex_scipy_distributions
     notebooks/ex_sensitivity
@@ -17,3 +21,5 @@ Tutorials
     notebooks/ex_load_combinations
     notebooks/ex_load_calibration
     notebooks/ex_load_calibration_nonlinear
+
+.. _`Python documentation`: http://www.python.org/doc/


### PR DESCRIPTION
Hi pystra team. 

A while since I have been looking at this and after running some old code noticed some major changes since my last upstream pull, including now a separate method for running the reliability analysis. I noticed this was not mentioned in the documentation's "Introductory Turorial" (`intro.rst`), but was in the "Example from the Tutorial" (`ex_intro.ipynb`). Since both are located in "Tutorials", I have decided streamline the documentation and updating `ex_intro.ipynb` to just have the one "Introductory Tutorial" (with the heading typo now fixed!) to avoid any future confusion.

Note file `intro.rst` still remains in the directory, but could be deleted if desired.

Moreover, an omission for the file on how to contribute to the documentation (`developer.rst`) has also been updated.