### PR TITLE
Fix FORM gamma diagonal computation

### DIFF
--- a/src/pystra/form.py
+++ b/src/pystra/form.py
@@ -176,7 +176,7 @@ class Form(AnalysisObject):
 
     def computeGamma(self):
         """Compute gamma vector"""
-        self.gamma = np.diag(np.diag(np.sqrt(np.dot(self.J, np.transpose(self.J)))))
+        self.gamma = np.diag(np.sqrt(np.diag(np.dot(self.J, np.transpose(self.J)))))
         # Importance vector gamma
         # matmult = np.dot(np.dot(self.alpha, self.J), self.gamma)
         # importance_vector_gamma = matmult / np.linalg.norm(matmult)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,17 @@
+import warnings
+
+import numpy as np
+
+from pystra.form import Form
+
+
+def test_compute_gamma_uses_diagonal_without_offdiagonal_warning():
+    form = Form()
+    form.J = np.array([[1.0, 0.0], [-0.5, 1.0]])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        form.computeGamma()
+
+    expected = np.diag(np.sqrt(np.diag(form.J @ form.J.T)))
+    np.testing.assert_allclose(form.gamma, expected)


### PR DESCRIPTION
## Summary

Fix `Form.computeGamma()` so it only takes the square root of the diagonal entries of `J @ J.T`.

The previous implementation applied `np.sqrt()` to the full matrix before extracting the diagonal. Valid Jacobian products can have negative off-diagonal entries, which produced unnecessary `RuntimeWarning: invalid value encountered in sqrt` warnings even though the retained diagonal entries were positive.

## Validation

- `conda run -n sanremo python -m pytest`
- San Remo FORM diagnostic with `RuntimeWarning` from `pystra.form` promoted to an error
