### PR TITLE
Add system reliability topology tools

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,6 +8,11 @@ the source-code docstrings using Sphinx ``autosummary``.
 Core Framework
 --------------
 
+.. toctree::
+    :maxdepth: 1
+
+    system
+
 .. autosummary::
     :toctree: gen
     :template: custom-module-template.rst
@@ -15,6 +20,7 @@ Core Framework
 
     pystra.model
     pystra.analysis
+    pystra.system
 
 Reliability Methods
 -------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,21 @@ All notable changes to Pystra are documented here.
 
 The format follows `Keep a Changelog <https://keepachangelog.com/>`_.
 
+Unreleased
+----------
+
+Added
+~~~~~
+- ``pystra.system`` module for composing named component limit states into
+  nested series, parallel, k-of-n, cut-set, and tie-set system limit states.
+- ``pystra.ditlevsen_bounds`` for second-order bounds from component event
+  probabilities and pairwise intersections.
+- System reliability documentation covering scope, usage, and the split
+  between physical-space system composition and isoprobabilistic
+  transformations.
+- System reliability tutorial notebook and theory content with classical
+  benchmark references.
+
 v1.6.0 (2026-03-16)
 --------------------
 

--- a/docs/source/notebooks/ex_system_reliability.ipynb
+++ b/docs/source/notebooks/ex_system_reliability.ipynb
@@ -1,0 +1,443 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "09515804",
+   "metadata": {},
+   "source": [
+    "# System Reliability\n",
+    "\n",
+    "This notebook demonstrates the `pystra.system` topology layer on classical system-reliability examples. The key distinction is that Pystra asks the user to encode the system event they intend to analyse; it does not infer the structural topology automatically.\n",
+    "\n",
+    "The examples cover:\n",
+    "\n",
+    "| Example | Reference | Purpose |\n",
+    "|---|---|---|\n",
+    "| [Four-branch case](https://pystra.github.io/pystra/references.html#ref-schueremans-2005) | [Schueremans2005](https://pystra.github.io/pystra/references.html#ref-schueremans-2005) | Series system as a minimum of branch limit states |\n",
+    "| [Daniels bundle](https://pystra.github.io/pystra/references.html#ref-daniels-1945) | [Daniels1945](https://pystra.github.io/pystra/references.html#ref-daniels-1945) | Classical equal-load-sharing benchmark |\n",
+    "| k-of-n system | [Ditlevsen2007](https://pystra.github.io/pystra/references.html#ref-ditlevsen-2007) | Event-counting topology |\n",
+    "| [Cut-set system](https://pystra.github.io/pystra/references.html#ref-song-2003) | [Song2003](https://pystra.github.io/pystra/references.html#ref-song-2003) | Minimal cut-set encoding |\n",
+    "| [Ditlevsen bounds](https://pystra.github.io/pystra/references.html#ref-ditlevsen-1979) and [Mainçon series benchmark](https://pystra.github.io/pystra/references.html#ref-maincon-2000) | [Ditlevsen1979](https://pystra.github.io/pystra/references.html#ref-ditlevsen-1979), [Maincon2000](https://pystra.github.io/pystra/references.html#ref-maincon-2000) | Bounds from component and pairwise event probabilities |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "218a3110",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.069397Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.069340Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.582506Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.582196Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "from scipy.stats import binom\n",
+    "\n",
+    "for candidate in (Path.cwd(), *Path.cwd().parents):\n",
+    "    src = candidate / \"src\"\n",
+    "    if (src / \"pystra\").exists():\n",
+    "        sys.path.insert(0, str(src))\n",
+    "        break\n",
+    "\n",
+    "import pystra as ra\n",
+    "\n",
+    "rng = np.random.default_rng(20260425)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "271cda40",
+   "metadata": {},
+   "source": [
+    "## Four-Branch Series System\n",
+    "\n",
+    "The [four-branch case](https://pystra.github.io/pystra/references.html#ref-schueremans-2005) is a standard benchmark for algorithms that must find several disconnected failure regions. It is naturally a series system:\n",
+    "\n",
+    "$$\n",
+    "g_\\mathrm{sys}(x) = \\min(g_1, g_2, g_3, g_4).\n",
+    "$$\n",
+    "\n",
+    "For independent $X_1, X_2 \\sim \\mathcal{N}(0, 1)$, the branch functions are:\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "g_1 &= 3 + 0.1(X_1 - X_2)^2 - \\frac{X_1 + X_2}{\\sqrt{2}}, \\\\\n",
+    "g_2 &= 3 + 0.1(X_1 - X_2)^2 + \\frac{X_1 + X_2}{\\sqrt{2}}, \\\\\n",
+    "g_3 &= (X_1 - X_2) + \\frac{6}{\\sqrt{2}}, \\\\\n",
+    "g_4 &= (X_2 - X_1) + \\frac{6}{\\sqrt{2}}.\n",
+    "\\end{aligned}\n",
+    "$$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "987cb138",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.583651Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.583526Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.592792Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.592567Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.00434, 0.0338684769766651)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sqrt2 = np.sqrt(2.0)\n",
+    "four_branch = ra.SeriesSystem(\n",
+    "    [\n",
+    "        ra.Component(\"g1\", lambda X1, X2: 3.0 + 0.1 * (X1 - X2) ** 2 - (X1 + X2) / sqrt2),\n",
+    "        ra.Component(\"g2\", lambda X1, X2: 3.0 + 0.1 * (X1 - X2) ** 2 + (X1 + X2) / sqrt2),\n",
+    "        ra.Component(\"g3\", lambda X1, X2: (X1 - X2) + 6.0 / sqrt2),\n",
+    "        ra.Component(\"g4\", lambda X1, X2: (X2 - X1) + 6.0 / sqrt2),\n",
+    "    ],\n",
+    "    name=\"four_branch\",\n",
+    ")\n",
+    "\n",
+    "n_samples = 200_000\n",
+    "x1 = rng.standard_normal(n_samples)\n",
+    "x2 = rng.standard_normal(n_samples)\n",
+    "failed = four_branch.failure_mask(X1=x1, X2=x2)\n",
+    "\n",
+    "pf_hat = failed.mean()\n",
+    "cov_hat = np.sqrt((1.0 - pf_hat) / (n_samples * pf_hat))\n",
+    "float(pf_hat), float(cov_hat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1db432b",
+   "metadata": {},
+   "source": [
+    "The estimate should be close to the usual reference probability of about $4.5 \\times 10^{-3}$. The precise Monte Carlo value changes with the sample size and seed; the point here is that the system topology is encoded directly from the branch functions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e23bafca",
+   "metadata": {},
+   "source": [
+    "## Daniels Equal-Load-Sharing Bundle\n",
+    "\n",
+    "[Daniels' six-thread example](https://pystra.github.io/pystra/references.html#ref-daniels-1945) gives the individual thread strengths\n",
+    "\n",
+    "$$\n",
+    "3.2,\\ 5.2,\\ 4.4,\\ 8.2,\\ 6.1,\\ 5.7.\n",
+    "$$\n",
+    "\n",
+    "For an equal-load-sharing bundle, sort the strengths in descending order and compute $r\\sigma_r$. The bundle strength is the maximum of those products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "939a4186",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.593545Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.593484Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.595393Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.595244Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([[ 1. ,  8.2,  8.2],\n",
+       "        [ 2. ,  6.1, 12.2],\n",
+       "        [ 3. ,  5.7, 17.1],\n",
+       "        [ 4. ,  5.2, 20.8],\n",
+       "        [ 5. ,  4.4, 22. ],\n",
+       "        [ 6. ,  3.2, 19.2]]),\n",
+       " 22.0)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thread_strengths = np.array([3.2, 5.2, 4.4, 8.2, 6.1, 5.7])\n",
+    "ordered_strengths = np.sort(thread_strengths)[::-1]\n",
+    "remaining_threads = np.arange(1, len(ordered_strengths) + 1)\n",
+    "bundle_loads = remaining_threads * ordered_strengths\n",
+    "\n",
+    "np.column_stack([remaining_threads, ordered_strengths, bundle_loads]), float(bundle_loads.max())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "987d18e4",
+   "metadata": {},
+   "source": [
+    "The maximum is 22.0, matching Daniels' published example. This is not a `KofNSystem`: after each thread breaks, the load redistributes, so the limit state depends on order statistics rather than only a fixed number of failed components."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c26d2c1",
+   "metadata": {},
+   "source": [
+    "## k-of-n Topology\n",
+    "\n",
+    "A k-of-n system fails when at least `k` components have failed. This event-counting representation is useful for simulation and exact Boolean enumeration, but it is discontinuous and should not be treated as a smooth FORM/SORM limit state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3e754d2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.596019Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.595965Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.598490Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.598343Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.00222984375, 0.00222984375)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_components = 6\n",
+    "k_failures = 3\n",
+    "component_pf = 0.05\n",
+    "\n",
+    "components = [\n",
+    "    ra.Component(f\"E{i}\", lambda event=f\"E{i}\", **kwargs: kwargs[event])\n",
+    "    for i in range(n_components)\n",
+    "]\n",
+    "k_of_n = ra.KofNSystem(components, k=k_failures, name=\"three_of_six\")\n",
+    "\n",
+    "states = np.array(list(itertools.product([False, True], repeat=n_components))).T\n",
+    "state_values = {f\"E{i}\": np.where(states[i], -1.0, 1.0) for i in range(n_components)}\n",
+    "weights = np.prod(np.where(states, component_pf, 1.0 - component_pf), axis=0)\n",
+    "\n",
+    "pf_enumerated = weights[k_of_n.failure_mask(**state_values)].sum()\n",
+    "pf_binomial = binom.sf(k_failures - 1, n_components, component_pf)\n",
+    "float(pf_enumerated), float(pf_binomial)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188c0ec7",
+   "metadata": {},
+   "source": [
+    "The exact enumeration agrees with the binomial result because the component events were independent and identically distributed in this example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "071f64dd",
+   "metadata": {},
+   "source": [
+    "## Minimal Cut Sets\n",
+    "\n",
+    "[Song and Der Kiureghian's rigid-plastic cantilever-bar example](https://pystra.github.io/pystra/references.html#ref-song-2003) uses the system failure event\n",
+    "\n",
+    "$$\n",
+    "E_\\mathrm{sys} = E_1E_2 \\cup E_3E_4 \\cup E_3E_5.\n",
+    "$$\n",
+    "\n",
+    "Pystra can encode this topology directly. The probability calculation in the paper uses component and joint event probabilities with linear-programming bounds; those LP bounds are a later extension. The topology itself is already usable for simulation when the component limit states are available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "71f625af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.599031Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.598977Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.601222Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.600959Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([False,  True,  True,  True])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cut_components = {\n",
+    "    name: ra.Component(name, lambda event=name, **kwargs: kwargs[event])\n",
+    "    for name in (\"E1\", \"E2\", \"E3\", \"E4\", \"E5\")\n",
+    "}\n",
+    "\n",
+    "cantilever_system = ra.CutSetSystem(\n",
+    "    [[\"E1\", \"E2\"], [\"E3\", \"E4\"], [\"E3\", \"E5\"]],\n",
+    "    components=cut_components,\n",
+    "    name=\"cantilever_cut_sets\",\n",
+    ")\n",
+    "\n",
+    "example_events = {\n",
+    "    \"E1\": np.array([False, True, False, False]),\n",
+    "    \"E2\": np.array([False, True, False, True]),\n",
+    "    \"E3\": np.array([True, False, True, True]),\n",
+    "    \"E4\": np.array([False, False, True, False]),\n",
+    "    \"E5\": np.array([False, False, False, True]),\n",
+    "}\n",
+    "example_values = {name: np.where(mask, -1.0, 1.0) for name, mask in example_events.items()}\n",
+    "\n",
+    "cantilever_system.failure_mask(**example_values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bed8bb8b",
+   "metadata": {},
+   "source": [
+    "The four samples above fail only when at least one of the supplied cut sets is complete."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ce374b5",
+   "metadata": {},
+   "source": [
+    "## Ditlevsen Bounds\n",
+    "\n",
+    "[Ditlevsen bounds](https://pystra.github.io/pystra/references.html#ref-ditlevsen-1979) use component event probabilities and pairwise intersections to bound a union of failure events. For two events the result collapses to exact inclusion-exclusion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3093dcfe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.601831Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.601785Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.603253Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.603116Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.27, 0.27)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ra.ditlevsen_bounds([0.1, 0.2], {(0, 1): 0.03})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ca04257",
+   "metadata": {},
+   "source": [
+    "[Mainçon's identical 100-element series-system example](https://pystra.github.io/pystra/references.html#ref-maincon-2000) reports component failure probability $P_1 = 1.969 \\times 10^{-3}$ and pairwise intersection probability $P_{12} = 1.361 \\times 10^{-3}$. With equal pairwise intersections, the Ditlevsen upper bound is approximately $6.216 \\times 10^{-2}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "50187b3d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T09:42:02.603724Z",
+     "iopub.status.busy": "2026-04-25T09:42:02.603681Z",
+     "iopub.status.idle": "2026-04-25T09:42:02.605703Z",
+     "shell.execute_reply": "2026-04-25T09:42:02.605542Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.0025769999999999994, 0.06216099999999983)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_events = 100\n",
+    "p1 = 1.969e-3\n",
+    "p12 = 1.361e-3\n",
+    "\n",
+    "probabilities = np.full(n_events, p1)\n",
+    "intersections = np.full((n_events, n_events), p12)\n",
+    "np.fill_diagonal(intersections, p1)\n",
+    "\n",
+    "ra.ditlevsen_bounds(probabilities, intersections)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc7d615e",
+   "metadata": {},
+   "source": [
+    "These bounds are deliberately separate from the topology classes. A topology tells Pystra which samples fail; Ditlevsen bounds require marginal and pairwise event probabilities, usually obtained from component analyses, simulation, or reference data."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -8,8 +8,8 @@ References
 
 .. [Bourinet2017] J.-M. Bourinet. "FORM Sensitivities to Distribution Parameters with the Nataf Transformation". In: P. Gardoni (ed.), Risk and Reliability Analysis: Theory and Applications, Springer Series in Reliability Engineering, pp. 277–302, 2017. DOI: 10.1007/978-3-319-52425-2_12.
 
-Breitung 1984
--------------
+.. _breitung-1984:
+.. _/references.rst#breitung-1984:
 
 .. [Breitung1984] Breitung, K. 1984 Asymptotic approximations for multinormal integrals. J. Eng. Mech. ASCE 110, 357–367.
 
@@ -18,6 +18,8 @@ Breitung 1984
 .. [Hackl2013] Hackl, J. (2013). Generic Framework for Stochastic Modeling of Reinforced Concrete Deterioration Caused by Corrosion. Master's thesis, Norwegian University of Science and Technology, NTNU.
 
 .. [Melchers1999] Melchers, R. E. (1999). Structural Reliability Analysis and Prediction. Second edition. Chichester, UK: John Wiley and Sons. isbn: 9780471987710.
+
+.. [Meinen2025] Meinen, N. E. (2025). "Application of the Rosenblatt transformation in First-Order System Reliability approximations". In: Structural Safety Vol 112, 102521. `doi:10.1016/j.strusafe.2024.102521 <https://doi.org/10.1016/j.strusafe.2024.102521>`_.
 
 .. [Hohenbichler1988] Hohenbichler, M. & Rackwitz, R. 1988 Improvement of second-order reliability estimates by importance sampling. J. Eng. Mech. ASCE 14, 2195–2199.
 
@@ -29,7 +31,13 @@ Breitung 1984
 
 .. [Nowak2000] Nowak, Andrzej S. and Kevin R. Collins (2000). Reliability of Structures. first edition. McGraw-Hill civil engineering series. McGraw-Hill Higher Education. isbn: 9780070481633.
 
+.. _ref-ditlevsen-2007:
+
 .. [Ditlevsen2007] Ditlevsen, Ove and Henrik O. Madsen (2007). Structural Reliability Methods. Internet edition 2.3.7. published online. Chichester, UK: John Wiley and Sons.
+
+.. _ref-ditlevsen-1979:
+
+.. [Ditlevsen1979] Ditlevsen, O. (1979). "Narrow reliability bounds for structural systems". Journal of Structural Mechanics, 7(4), 435-451. `doi:10.1080/03601217908905328 <https://doi.org/10.1080/03601217908905328>`_.
 
 .. [Baker2010] Baker, Jack (2010). CEE 204: Structrual Reliability. Lecture notes. Stanford University.
 
@@ -43,8 +51,8 @@ Breitung 1984
 
 .. [Thoft-Christensen] Thoft-Christensen, Palle and Michael J. Baker (1982). Structural Reliability Theory and its Applications. Heidelberg: Springer Verlag. isbn: 9783540117315.
 
-Sorensen 2004
--------------
+.. _sorensen-2004:
+.. _/references.rst#sorensen-2004:
 
 .. [Sorensen2004] J. D. Sørensen. Notes in Structural Reliability Theory and Risk Analysis. Aalborg University, 2004.
 
@@ -56,7 +64,23 @@ Sorensen 2004
 
 .. [Koutsourelakis2004] Koutsourelakis, P. S., Pradlwarter, H. J., & Schuëller, G. I. (2004). Reliability of structures in high dimensions, Part I: algorithms and applications. Probabilistic Engineering Mechanics, 19(4), 409–417.
 
-Schueller and Pradlwarter 2007
-------------------------------
+.. _schueller-and-pradlwarter-2007:
+.. _/references.rst#schueller-and-pradlwarter-2007:
 
 .. [Schueller2007] Schuëller, G. I., & Pradlwarter, H. J. (2007). Benchmark study on reliability estimation in higher dimensions of structural systems — An overview. Structural Safety, 29(3), 167–182.
+
+.. _ref-schueremans-2005:
+
+.. [Schueremans2005] Schueremans, L. & Van Gemert, D. (2005). "Benefit of splines and neural networks in simulation based structural reliability analysis". Structural Safety, 27(3), 246-261. `doi:10.1016/j.strusafe.2004.11.001 <https://doi.org/10.1016/j.strusafe.2004.11.001>`_.
+
+.. _ref-maincon-2000:
+
+.. [Maincon2000] Mainçon, P. (2000). "A first order reliability method for series systems". Structural Safety, 22(1), 5-26. `doi:10.1016/S0167-4730(99)00036-3 <https://doi.org/10.1016/S0167-4730(99)00036-3>`_.
+
+.. _ref-song-2003:
+
+.. [Song2003] Song, J. and Der Kiureghian, A. (2003). "Bounds on system reliability by linear programming". Journal of Engineering Mechanics, 129(6), 627-636. `doi:10.1061/(ASCE)0733-9399(2003)129:6(627) <https://doi.org/10.1061/(ASCE)0733-9399(2003)129:6(627)>`_.
+
+.. _ref-daniels-1945:
+
+.. [Daniels1945] Daniels, H. E. (1945). "The statistical theory of the strength of bundles of threads. I". Proceedings of the Royal Society of London. Series A, Mathematical and Physical Sciences, 183(995), 405-435. `doi:10.1098/rspa.1945.0011 <https://doi.org/10.1098/rspa.1945.0011>`_.

--- a/docs/source/system.rst
+++ b/docs/source/system.rst
@@ -1,0 +1,185 @@
+.. _chap_system:
+
+******************
+System Reliability
+******************
+
+Pystra supports simple structural system composition through the
+``pystra.system`` module.  The module does not introduce a separate
+probability approximation method.  It builds an equivalent scalar
+limit-state function from named component limit states, and that function can
+then be used with the existing FORM, SORM, Monte Carlo, line sampling, subset
+simulation workflows.
+
+The sign convention is the usual Pystra convention: positive values are safe
+and negative values indicate failure.
+
+Series and Parallel Systems
+===========================
+
+A series system fails when any child component or subsystem fails.  Its
+equivalent limit-state value is therefore
+
+.. math::
+
+   g_\mathrm{series}(x) = \min_i g_i(x).
+
+A parallel system fails only when all child components or subsystems fail.  Its
+equivalent limit-state value is therefore
+
+.. math::
+
+   g_\mathrm{parallel}(x) = \max_i g_i(x).
+
+Systems can be nested, so a user can describe a known structural topology
+without enumerating every failure path manually.  This includes common branch
+system benchmarks such as the :ref:`four-branch series example
+<ref-schueremans-2005>`.
+
+Example
+=======
+
+.. code-block:: python
+
+   import pystra as ra
+
+   system = ra.SeriesSystem(
+       [
+           ra.Component("flexure", lambda R, S: R - S),
+           ra.Component("shear", lambda V, S: V - 2.0 * S),
+           ra.ParallelSystem(
+               [
+                   ra.Component("backup_a", lambda A: A),
+                   ra.Component("backup_b", lambda B: B),
+               ]
+           ),
+       ],
+       name="frame",
+   )
+
+   limit_state = system.as_limit_state()
+
+   model = ra.StochasticModel()
+   model.addVariable(ra.Normal("R", 10.0, 1.0))
+   model.addVariable(ra.Normal("V", 12.0, 1.0))
+   model.addVariable(ra.Normal("S", 4.0, 1.0))
+   model.addVariable(ra.Normal("A", 1.0, 0.5))
+   model.addVariable(ra.Normal("B", 1.0, 0.5))
+
+   form = ra.Form(stochastic_model=model, limit_state=limit_state)
+   form.run()
+
+Component functions may use only the stochastic variables they need.  Extra
+model variables are filtered at the component boundary, which keeps small
+component functions reusable inside larger systems.
+
+Event Topologies
+================
+
+Structural systems are often specified as event logic once the engineer has
+identified the relevant component limit states.  Pystra provides three small
+helpers for that layer:
+
+``KofNSystem``
+   fails when at least ``k`` children fail.  ``KofNSystem(children, k=1)`` has
+   the same failure event as a series system, and ``KofNSystem(children, k=n)``
+   has the same failure event as a parallel system.
+
+``CutSetSystem``
+   fails when any supplied cut set has fully failed.  This is useful when the
+   user already knows the minimal cut sets of the structure.
+
+``TieSetSystem``
+   remains safe when any supplied tie set remains fully safe.  This is useful
+   for path-based descriptions of redundant systems.
+
+For example, :ref:`Song and Der Kiureghian's rigid-plastic cantilever-bar
+benchmark <ref-song-2003>`
+has the system failure event
+
+.. math::
+
+   E_\mathrm{sys} = E_1 E_2 \cup E_3 E_4 \cup E_3 E_5.
+
+This can be represented directly from named components:
+
+.. code-block:: python
+
+   components = {
+       "E1": ra.Component("E1", lambda T, X: T - 5.0 * X / 16.0),
+       "E2": ra.Component("E2", lambda M, L, X: M - L * X),
+       "E3": ra.Component("E3", lambda M, L, X: M - 3.0 * L * X / 8.0),
+       "E4": ra.Component("E4", lambda M, L, X: M - L * X / 3.0),
+       "E5": ra.Component("E5", lambda M, L, T, X: M + 2.0 * L * T - L * X),
+   }
+
+   system = ra.CutSetSystem(
+       [["E1", "E2"], ["E3", "E4"], ["E3", "E5"]],
+       components=components,
+   )
+
+Event-counting and cut/tie-set systems preserve the correct failure sign for
+simulation, subset simulation, and Boolean enumeration.  They are not generally
+smooth limit-state functions, so FORM/SORM results should be interpreted with
+care unless the topology reduces to a smooth min/max envelope.
+
+Ditlevsen Bounds
+================
+
+When component event probabilities and pairwise intersection probabilities are
+available, :func:`pystra.ditlevsen_bounds` computes :ref:`Ditlevsen's
+second-order bounds <ref-ditlevsen-1979>` for a union of failure
+events.  The event ordering can be supplied explicitly, or exhaustively
+optimized for small systems.
+
+.. code-block:: python
+
+   probabilities = [0.1, 0.2]
+   intersections = {(0, 1): 0.03}
+
+   lower, upper = ra.ditlevsen_bounds(probabilities, intersections)
+
+For two events the bounds collapse to the exact inclusion-exclusion result.
+For larger systems they provide a cheap check on simulation estimates and a
+useful validation target for future system FORM approximations.  The initial
+test suite includes :ref:`Mainçon's identical 100-element series benchmark
+<ref-maincon-2000>`, where the Ditlevsen
+upper bound is approximately ``6.216e-2``.
+
+Scope and Transformations
+=========================
+
+The system module composes limit-state functions in the original physical
+variables.  The isoprobabilistic transformation to standard space remains the
+responsibility of the selected Pystra analysis method and its
+``AnalysisOptions``.  This keeps system topology separate from the probability
+transformation, following the same conceptual split used in structural
+reliability methods generally.
+
+This first implementation deliberately avoids first-order system reliability
+method approximations and automatic failure-path enumeration.  Those methods
+can be useful, but they need additional assumptions about the component
+design points, dependence model, and transformation ordering.  In particular,
+Rosenblatt-based first-order system approximations can be sensitive to the
+conditioning order used for the transformation [Meinen2025]_.  For now,
+simulation methods can estimate the probability of failure from the composed
+system limit-state function directly.
+
+Validation Benchmarks
+=====================
+
+The current validation suite checks exact Boolean behaviour for series,
+parallel, k-of-n, cut-set, and tie-set systems; integration with Pystra's
+``LimitState`` evaluation; a FORM smoke test for smooth min/max systems; and
+Ditlevsen bounds for simple and published series-system cases.
+
+The next benchmarks to add before extending the approximation methods are:
+
+- :ref:`Ditlevsen frame examples <ref-ditlevsen-1979>`;
+- :ref:`Song and Der Kiureghian's rigid-plastic cantilever-bar cut-set example
+  <ref-song-2003>`
+  and linear-programming bounds;
+- :ref:`Daniels equal-load-sharing bundle examples <ref-daniels-1945>`
+  [Daniels1945]_;
+- :ref:`Mainçon's correlated series-system cases <ref-maincon-2000>` and
+  related equivalent planes comparisons.

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -587,6 +587,174 @@ process objects to create explicit named leading-action cases.  The result is
 still an ordinary :class:`~pystra.loadcomb.LoadCombination`; the generated
 cases simply make the FBC and Turkstra assumptions visible in the model.
 
+System Reliability
+==================
+
+System reliability concerns a structure whose failure is governed by more than
+one component event.  If the component limit states are
+:math:`g_i({\bf X})`, the component failure events are
+
+.. math::
+
+   F_i = \{g_i({\bf X}) \leq 0\}.
+
+For a series system the system failure event is the union of component failure
+events,
+
+.. math::
+
+   F_\mathrm{series} = \bigcup_{i=1}^{n} F_i,
+
+and the equivalent scalar limit-state function can be written as
+
+.. math::
+
+   g_\mathrm{series}({\bf X}) = \min_i g_i({\bf X}).
+
+For a parallel system the system failure event is the intersection of component
+failure events,
+
+.. math::
+
+   F_\mathrm{parallel} = \bigcap_{i=1}^{n} F_i,
+
+with equivalent scalar limit-state function
+
+.. math::
+
+   g_\mathrm{parallel}({\bf X}) = \max_i g_i({\bf X}).
+
+These min/max forms are useful because they preserve the standard Pystra sign
+convention: positive means safe and non-positive means failed.  They also
+allow the same system definition to be passed to simulation methods, active
+learning, and, when the envelope is sufficiently smooth near the controlling
+point, FORM/SORM.
+
+k-of-n, Cut-Set, and Tie-Set Systems
+------------------------------------
+
+More general topologies are often described in terms of events rather than a
+single analytic limit-state expression [Ditlevsen2007]_.  A k-of-n system
+fails when at least :math:`k` component events have occurred:
+
+.. math::
+
+   F_{k|n} =
+   \left\{\sum_{i=1}^{n} I(F_i) \geq k\right\},
+
+where :math:`I(F_i)` is one if event :math:`F_i` occurs and zero otherwise.
+This representation is exact for Boolean enumeration and simulation, but it is
+not generally differentiable.
+
+If the minimum cut sets :math:`C_m` are known, the system failure event can be
+written as
+
+.. math::
+
+   F_\mathrm{sys} =
+   \bigcup_{m=1}^{n_c} \left(\bigcap_{i \in C_m} F_i\right).
+
+The dual path, or tie-set, representation writes the safe event as the union
+of working tie sets.  For tie sets :math:`T_m`,
+
+.. math::
+
+   S_\mathrm{sys} =
+   \bigcup_{m=1}^{n_t} \left(\bigcap_{i \in T_m} \bar{F}_i\right).
+
+Cut-set and tie-set descriptions are common in structural system reliability
+because they let the engineer encode known collapse mechanisms or load paths
+without enumerating every possible Boolean state [Song2003]_.
+
+Ditlevsen Bounds
+----------------
+
+For a series system, exact evaluation of
+:math:`P(\cup_i F_i)` may require high-dimensional integration over a union of
+failure domains.  If the component probabilities :math:`P(F_i)` and pairwise
+intersections :math:`P(F_i \cap F_j)` are available, Ditlevsen's bounds give a
+second-order estimate of the union probability [Ditlevsen1979]_.  For a chosen
+event ordering, the lower bound is
+
+.. math::
+
+   P_L =
+   P(F_1) +
+   \sum_{i=2}^{n}
+   \max\left[
+      P(F_i) - \sum_{j=1}^{i-1} P(F_i \cap F_j),\ 0
+   \right],
+
+and the upper bound is
+
+.. math::
+
+   P_U =
+   \sum_{i=1}^{n} P(F_i)
+   - \sum_{i=2}^{n} \max_{1 \leq j < i} P(F_i \cap F_j).
+
+The bounds depend on event ordering.  For small systems the ordering can be
+checked exhaustively; for large systems, the ordering should be chosen using
+engineering judgement or a heuristic.  Mainçon's 100-element series-system
+benchmark is a useful validation case because it reports component and
+pairwise probabilities directly [Maincon2000]_.
+
+Linear-programming bounds generalise this idea to arbitrary systems and
+arbitrary available event information.  Song and Der Kiureghian showed that LP
+bounds can use component, pairwise, and higher-order event probabilities for
+general cut-set systems, including the rigid-plastic cantilever-bar benchmark
+[Song2003]_.  This is a natural extension beyond the current Ditlevsen bounds
+API.
+
+Four-Branch Case
+----------------
+
+The four-branch case is a widely used benchmark for reliability algorithms
+because it has multiple disconnected failure regions [Schueremans2005]_.  With
+independent standard normal variables :math:`X_1` and :math:`X_2`, it is
+defined by
+
+.. math::
+
+   g_\mathrm{FBC}({\bf X}) = \min(g_1, g_2, g_3, g_4),
+
+where
+
+.. math::
+
+   \begin{aligned}
+   g_1 &= 3 + 0.1(X_1 - X_2)^2 - \frac{X_1 + X_2}{\sqrt{2}}, \\
+   g_2 &= 3 + 0.1(X_1 - X_2)^2 + \frac{X_1 + X_2}{\sqrt{2}}, \\
+   g_3 &= (X_1 - X_2) + \frac{6}{\sqrt{2}}, \\
+   g_4 &= (X_2 - X_1) + \frac{6}{\sqrt{2}}.
+   \end{aligned}
+
+The benchmark is a series system in event terms, but a single FORM analysis
+can find only one local design point.  Simulation, subset simulation, and
+active-learning methods are therefore better suited to estimating the global
+failure probability unless a dedicated first-order system reliability method
+is used.
+
+First-Order System Reliability
+------------------------------
+
+First-order system reliability methods approximate each component failure
+surface near its design point and then integrate the resulting system event in
+standard normal space.  This requires more information than a scalar topology:
+component design points, component normal vectors, dependence between
+linearised events, and a clear isoprobabilistic transformation.  Rosenblatt
+transformations add an additional ordering issue because the transformed
+standard-space geometry can depend on the conditioning order [Meinen2025]_.
+
+For this reason Pystra currently separates three tasks:
+
+1. users encode the system topology using series, parallel, k-of-n, cut-set,
+   or tie-set systems;
+2. existing simulation and active-learning methods estimate the resulting
+   failure probability directly;
+3. analytical bounds such as Ditlevsen bounds are computed from event
+   probabilities when those probabilities are available.
+
 
 Simulation Methods
 ==================

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -22,3 +22,4 @@ page.
     notebooks/ex_load_combinations
     notebooks/ex_factor_calibration
     notebooks/ex_generic_calibration
+    notebooks/ex_system_reliability

--- a/src/pystra/__init__.py
+++ b/src/pystra/__init__.py
@@ -55,6 +55,7 @@ from .sorm import *
 from .ls import *
 from .ss import *
 from .sensitivity import *
+from .system import *
 
 # Calibration
 from .fbc import *

--- a/src/pystra/system.py
+++ b/src/pystra/system.py
@@ -1,0 +1,516 @@
+"""System reliability limit-state composition.
+
+This module provides a small topology layer for structural system
+reliability.  It does not estimate system reliability directly.  Instead,
+it composes component limit-state functions into a single scalar limit-state
+function that can be passed to Pystra's existing reliability algorithms.
+
+The sign convention is the standard Pystra convention: positive values are
+safe, and negative values indicate failure.  A series system fails when any
+child fails, so its equivalent limit-state value is the minimum child value.
+A parallel system fails when all children fail, so its equivalent
+limit-state value is the maximum child value.
+"""
+
+from __future__ import annotations
+
+import inspect
+import itertools
+from typing import Callable, Iterable
+
+import numpy as np
+
+from .model import LimitState
+
+__all__ = [
+    "Component",
+    "System",
+    "SeriesSystem",
+    "ParallelSystem",
+    "KofNSystem",
+    "CutSetSystem",
+    "TieSetSystem",
+    "ditlevsen_bounds",
+]
+
+
+class Component:
+    """A named component limit state within a structural system.
+
+    Parameters
+    ----------
+    name : str or LimitState or callable
+        Component name.  For convenience, if *limit_state* is omitted this
+        argument is treated as the limit-state object and the name is inferred.
+    limit_state : LimitState or callable, optional
+        Component limit-state function.  Callables are wrapped in
+        :class:`~pystra.model.LimitState`.
+
+    Notes
+    -----
+    Component functions may use only a subset of the stochastic model
+    variables.  Extra keyword arguments are filtered unless the function
+    accepts ``**kwargs``.
+    """
+
+    def __init__(self, name, limit_state=None):
+        if limit_state is None:
+            limit_state = name
+            name = None
+
+        self.limit_state = _as_limit_state(limit_state)
+        self.name = _component_name(name, self.limit_state)
+        self._signature = _call_signature(self.limit_state.expression)
+
+    def evaluate(self, **kwargs):
+        """Evaluate the component limit state for one or more samples."""
+
+        values = self.limit_state.expression(**self._filter_kwargs(kwargs))
+        if isinstance(values, tuple):
+            values = values[0]
+        return np.asarray(values, dtype=float)
+
+    def as_limit_state(self):
+        """Return this component as a Pystra :class:`LimitState`."""
+
+        return self.limit_state
+
+    def getLimitState(self):
+        """Return this component as a Pystra :class:`LimitState`.
+
+        This legacy-style alias mirrors the existing Pystra getter naming.
+        """
+
+        return self.as_limit_state()
+
+    def iter_components(self):
+        """Yield leaf components in this subtree."""
+
+        yield self
+
+    @property
+    def components(self):
+        """Tuple containing this component."""
+
+        return (self,)
+
+    def failure_mask(self, **kwargs):
+        """Return a boolean mask where the component is failed."""
+
+        return self.evaluate(**kwargs) < 0
+
+    def _filter_kwargs(self, kwargs):
+        names, required, accepts_kwargs = self._signature
+        if accepts_kwargs:
+            return kwargs
+
+        missing = [name for name in required if name not in kwargs]
+        if missing:
+            missing_text = ", ".join(missing)
+            raise KeyError(
+                f"Component '{self.name}' is missing required input(s): "
+                f"{missing_text}"
+            )
+        return {name: kwargs[name] for name in names if name in kwargs}
+
+
+class System:
+    """Base class for composed structural system limit states."""
+
+    _operator_name = "system"
+
+    def __init__(self, children: Iterable, name=None):
+        children = tuple(_as_node(child, index) for index, child in enumerate(children))
+        if not children:
+            raise ValueError("A system must contain at least one child")
+
+        self.children = children
+        self.name = name or self._operator_name
+
+    @property
+    def components(self):
+        """Flat tuple of all leaf components in the system."""
+
+        return tuple(_unique_components(self.iter_components()))
+
+    def iter_components(self):
+        """Yield all leaf components in the system."""
+
+        for child in self.children:
+            yield from child.iter_components()
+
+    def evaluate(self, **kwargs):
+        """Evaluate the equivalent scalar system limit state."""
+
+        values = [child.evaluate(**kwargs) for child in self.children]
+        return self._combine(values)
+
+    def as_limit_state(self):
+        """Return the composed system as a Pystra :class:`LimitState`."""
+
+        return LimitState(lambda **kwargs: self.evaluate(**kwargs))
+
+    def getLimitState(self):
+        """Return the composed system as a Pystra :class:`LimitState`.
+
+        This legacy-style alias mirrors the existing Pystra getter naming.
+        """
+
+        return self.as_limit_state()
+
+    def component_values(self, **kwargs):
+        """Evaluate all leaf component limit states.
+
+        Returns
+        -------
+        dict
+            Mapping component names to their evaluated limit-state values.
+
+        Raises
+        ------
+        ValueError
+            If duplicate component names would make the mapping ambiguous.
+        """
+
+        values = {}
+        for component in self.components:
+            if component.name in values:
+                raise ValueError(
+                    f"Duplicate component name '{component.name}' in system"
+                )
+            values[component.name] = component.evaluate(**kwargs)
+        return values
+
+    def component_failure_masks(self, **kwargs):
+        """Return failure masks for each leaf component."""
+
+        return {
+            name: values < 0
+            for name, values in self.component_values(**kwargs).items()
+        }
+
+    def failure_mask(self, **kwargs):
+        """Return a boolean mask where the system is failed."""
+
+        return self.evaluate(**kwargs) < 0
+
+    def _combine(self, values):
+        raise NotImplementedError
+
+
+class SeriesSystem(System):
+    """A system that fails when any child component or subsystem fails.
+
+    The equivalent limit-state function is the minimum child limit-state
+    value.
+    """
+
+    _operator_name = "series"
+
+    def _combine(self, values):
+        arrays = _broadcast_values(values)
+        return np.min(arrays, axis=0)
+
+
+class ParallelSystem(System):
+    """A system that fails when all child components or subsystems fail.
+
+    The equivalent limit-state function is the maximum child limit-state
+    value.
+    """
+
+    _operator_name = "parallel"
+
+    def _combine(self, values):
+        arrays = _broadcast_values(values)
+        return np.max(arrays, axis=0)
+
+
+class KofNSystem(System):
+    """A system that fails when at least ``k`` child events fail.
+
+    Parameters
+    ----------
+    children : iterable
+        Child components or subsystems.
+    k : int
+        Number of failed children required for system failure.
+    name : str, optional
+        System name.
+
+    Notes
+    -----
+    This event-counting representation is intended for simulation,
+    enumeration, and topology construction.  Its equivalent limit-state value
+    preserves the failure sign but is discontinuous, so it is generally not a
+    smooth FORM/SORM limit state.
+    """
+
+    _operator_name = "k_of_n"
+
+    def __init__(self, children: Iterable, k, name=None):
+        super().__init__(children, name=name)
+        self.k = int(k)
+        if self.k < 1 or self.k > len(self.children):
+            raise ValueError("k must satisfy 1 <= k <= number of children")
+
+    def _combine(self, values):
+        arrays = _broadcast_values(values)
+        failed_count = np.count_nonzero(arrays < 0.0, axis=0)
+        return self.k - failed_count - 0.5
+
+
+class CutSetSystem(System):
+    """A system described by cut sets.
+
+    Each cut set is a group of component failures that causes system failure.
+    The system fails when any cut set has fully failed.
+
+    Parameters
+    ----------
+    cut_sets : iterable of iterables
+        Cut sets.  Entries may be components, subsystems, callables, or string
+        names when *components* is supplied.
+    components : mapping or iterable, optional
+        Component catalogue used to resolve string names in *cut_sets*.
+    name : str, optional
+        System name.
+    """
+
+    _operator_name = "cut_set"
+
+    def __init__(self, cut_sets, components=None, name=None):
+        resolved = _resolve_component_sets(cut_sets, components)
+        if not resolved:
+            raise ValueError("At least one cut set is required")
+
+        self.cut_sets = resolved
+        children = [ParallelSystem(cut_set) for cut_set in resolved]
+        super().__init__(children, name=name)
+
+    def _combine(self, values):
+        arrays = _broadcast_values(values)
+        return np.min(arrays, axis=0)
+
+
+class TieSetSystem(System):
+    """A system described by tie sets.
+
+    Each tie set is a group of components that keeps the system safe when all
+    components in that set are safe.  The system fails only when all tie sets
+    have failed.
+
+    Parameters
+    ----------
+    tie_sets : iterable of iterables
+        Tie sets.  Entries may be components, subsystems, callables, or string
+        names when *components* is supplied.
+    components : mapping or iterable, optional
+        Component catalogue used to resolve string names in *tie_sets*.
+    name : str, optional
+        System name.
+    """
+
+    _operator_name = "tie_set"
+
+    def __init__(self, tie_sets, components=None, name=None):
+        resolved = _resolve_component_sets(tie_sets, components)
+        if not resolved:
+            raise ValueError("At least one tie set is required")
+
+        self.tie_sets = resolved
+        children = [SeriesSystem(tie_set) for tie_set in resolved]
+        super().__init__(children, name=name)
+
+    def _combine(self, values):
+        arrays = _broadcast_values(values)
+        return np.max(arrays, axis=0)
+
+
+def ditlevsen_bounds(probabilities, intersections, ordering=None, optimize_order=False):
+    r"""Return Ditlevsen bounds for the probability of a union of events.
+
+    Parameters
+    ----------
+    probabilities : array_like
+        Event probabilities :math:`P(E_i)`.
+    intersections : array_like or mapping
+        Pairwise intersection probabilities :math:`P(E_i \cap E_j)`.  This may
+        be an ``n x n`` array, or a mapping keyed by ``(i, j)`` pairs.
+    ordering : sequence of int, optional
+        Event ordering used by Ditlevsen's sequential bounds.
+    optimize_order : bool, optional
+        If ``True``, all event orderings are checked and the tightest lower and
+        upper bounds are returned.  This is factorial in the number of events
+        and is limited to eight events.
+
+    Returns
+    -------
+    tuple of float
+        Lower and upper bounds for :math:`P(\cup_i E_i)`.
+    """
+
+    probabilities = np.asarray(probabilities, dtype=float)
+    if probabilities.ndim != 1:
+        raise ValueError("probabilities must be a one-dimensional sequence")
+    if len(probabilities) == 0:
+        raise ValueError("At least one event probability is required")
+    if np.any((probabilities < 0.0) | (probabilities > 1.0)):
+        raise ValueError("probabilities must be between 0 and 1")
+
+    pairwise = _intersection_matrix(intersections, len(probabilities))
+
+    if optimize_order:
+        if ordering is not None:
+            raise ValueError("ordering cannot be supplied with optimize_order=True")
+        if len(probabilities) > 8:
+            raise ValueError("optimize_order=True is limited to eight events")
+        bounds = [
+            _ditlevsen_bounds_for_order(probabilities, pairwise, candidate)
+            for candidate in itertools.permutations(range(len(probabilities)))
+        ]
+        return max(lower for lower, _ in bounds), min(upper for _, upper in bounds)
+
+    if ordering is None:
+        ordering = tuple(range(len(probabilities)))
+    return _ditlevsen_bounds_for_order(probabilities, pairwise, ordering)
+
+
+def _as_node(obj, index):
+    if isinstance(obj, (Component, System)):
+        return obj
+    return Component(f"component_{index}", obj)
+
+
+def _as_limit_state(obj):
+    if isinstance(obj, LimitState):
+        return obj
+    if callable(obj):
+        return LimitState(obj)
+    raise TypeError("limit_state must be a LimitState or callable")
+
+
+def _component_name(name, limit_state):
+    if name is not None:
+        return str(name)
+
+    expression = limit_state.expression
+    inferred = getattr(expression, "__name__", None)
+    if inferred and inferred != "<lambda>":
+        return inferred
+    return "component"
+
+
+def _call_signature(expression: Callable):
+    signature = inspect.signature(expression)
+    accepts_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    names = tuple(
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    )
+    required = tuple(
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        and parameter.default is inspect.Parameter.empty
+    )
+    return names, required, accepts_kwargs
+
+
+def _broadcast_values(values):
+    if not values:
+        raise ValueError("At least one value is required")
+    arrays = [np.asarray(value, dtype=float) for value in values]
+    return np.stack(np.broadcast_arrays(*arrays), axis=0)
+
+
+def _unique_components(components):
+    seen = set()
+    unique = []
+    for component in components:
+        identifier = id(component)
+        if identifier not in seen:
+            seen.add(identifier)
+            unique.append(component)
+    return unique
+
+
+def _resolve_component_sets(component_sets, components):
+    catalogue = _component_catalogue(components)
+    resolved_sets = []
+    for component_set in component_sets:
+        resolved = []
+        for component_index, component in enumerate(component_set):
+            if isinstance(component, str):
+                if component not in catalogue:
+                    raise KeyError(f"Unknown component name '{component}'")
+                resolved.append(catalogue[component])
+            else:
+                resolved.append(_as_node(component, component_index))
+        if not resolved:
+            raise ValueError("Component sets cannot be empty")
+        resolved_sets.append(tuple(resolved))
+    return tuple(resolved_sets)
+
+
+def _component_catalogue(components):
+    if components is None:
+        return {}
+    if isinstance(components, dict):
+        return {
+            str(name): _as_node(component, index)
+            for index, (name, component) in enumerate(components.items())
+        }
+
+    catalogue = {}
+    for index, component in enumerate(components):
+        node = _as_node(component, index)
+        if node.name in catalogue:
+            raise ValueError(f"Duplicate component name '{node.name}' in catalogue")
+        catalogue[node.name] = node
+    return catalogue
+
+
+def _intersection_matrix(intersections, n_events):
+    if isinstance(intersections, dict):
+        matrix = np.zeros((n_events, n_events), dtype=float)
+        for key, value in intersections.items():
+            i, j = key
+            matrix[i, j] = matrix[j, i] = float(value)
+    else:
+        matrix = np.asarray(intersections, dtype=float)
+
+    if matrix.shape != (n_events, n_events):
+        raise ValueError("intersections must be an n x n matrix or pair mapping")
+    if np.any((matrix < 0.0) | (matrix > 1.0)):
+        raise ValueError("intersections must be between 0 and 1")
+    if not np.allclose(matrix, matrix.T):
+        raise ValueError("intersections must be symmetric")
+    return matrix
+
+
+def _ditlevsen_bounds_for_order(probabilities, intersections, ordering):
+    order = tuple(ordering)
+    n_events = len(probabilities)
+    if sorted(order) != list(range(n_events)):
+        raise ValueError("ordering must be a permutation of event indices")
+
+    lower = probabilities[order[0]]
+    upper = np.sum(probabilities)
+    for position, event in enumerate(order[1:], start=1):
+        previous = order[:position]
+        previous_intersections = intersections[event, previous]
+        lower += max(probabilities[event] - np.sum(previous_intersections), 0.0)
+        upper -= np.max(previous_intersections)
+
+    return _clip_probability(lower), _clip_probability(upper)
+
+
+def _clip_probability(value):
+    return float(np.clip(value, 0.0, 1.0))

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,317 @@
+"""Tests for system reliability limit-state composition."""
+
+import numpy as np
+import pytest
+
+import pystra as ra
+
+
+def test_component_filters_unused_model_variables():
+    component = ra.Component("bending", lambda R, M: R - M)
+
+    result = component.evaluate(
+        R=np.array([10.0, 4.0]),
+        M=np.array([6.0, 5.0]),
+        unused=np.array([100.0, 100.0]),
+    )
+
+    np.testing.assert_allclose(result, np.array([4.0, -1.0]))
+
+
+def test_component_accepts_limit_state_instance():
+    limit_state = ra.LimitState(lambda R, S: R - S)
+    component = ra.Component("member", limit_state)
+
+    assert component.as_limit_state() is limit_state
+    np.testing.assert_allclose(
+        component.evaluate(R=np.array([5.0]), S=np.array([3.0])),
+        np.array([2.0]),
+    )
+
+
+def test_series_system_uses_minimum_child_limit_state():
+    system = ra.SeriesSystem(
+        [
+            ra.Component("flexure", lambda R, S: R - S),
+            ra.Component("shear", lambda V, S: V - 2.0 * S),
+        ]
+    )
+
+    result = system.evaluate(
+        R=np.array([10.0, 10.0]),
+        V=np.array([14.0, 6.0]),
+        S=np.array([5.0, 4.0]),
+    )
+
+    np.testing.assert_allclose(result, np.array([4.0, -2.0]))
+    np.testing.assert_array_equal(
+        system.failure_mask(
+            R=np.array([10.0, 10.0]),
+            V=np.array([14.0, 6.0]),
+            S=np.array([5.0, 4.0]),
+        ),
+        [False, True],
+    )
+
+
+def test_parallel_system_uses_maximum_child_limit_state():
+    system = ra.ParallelSystem(
+        [
+            ra.Component("support_a", lambda A: A - 1.0),
+            ra.Component("support_b", lambda B: B - 1.0),
+        ]
+    )
+
+    result = system.evaluate(A=np.array([2.0, 0.0]), B=np.array([3.0, 0.5]))
+
+    np.testing.assert_allclose(result, np.array([2.0, -0.5]))
+    np.testing.assert_array_equal(
+        system.failure_mask(A=np.array([2.0, 0.0]), B=np.array([3.0, 0.5])),
+        [False, True],
+    )
+
+
+def test_k_of_n_system_fails_when_k_children_fail():
+    system = ra.KofNSystem(
+        [
+            ra.Component("a", lambda A: A),
+            ra.Component("b", lambda B: B),
+            ra.Component("c", lambda C: C),
+        ],
+        k=2,
+    )
+
+    result = system.evaluate(
+        A=np.array([1.0, -1.0, -1.0, -1.0]),
+        B=np.array([1.0, 1.0, -1.0, -1.0]),
+        C=np.array([1.0, 1.0, 1.0, -1.0]),
+    )
+
+    np.testing.assert_allclose(result, np.array([1.5, 0.5, -0.5, -1.5]))
+    np.testing.assert_array_equal(
+        result < 0.0,
+        np.array([False, False, True, True]),
+    )
+
+
+def test_k_of_n_system_rejects_invalid_k():
+    with pytest.raises(ValueError, match="1 <= k"):
+        ra.KofNSystem([ra.Component("a", lambda A: A)], k=0)
+
+
+def test_nested_system_composition():
+    system = ra.SeriesSystem(
+        [
+            ra.Component("main", lambda G: G),
+            ra.ParallelSystem(
+                [
+                    ra.Component("backup_a", lambda A: A),
+                    ra.Component("backup_b", lambda B: B),
+                ]
+            ),
+        ]
+    )
+
+    result = system.evaluate(
+        G=np.array([2.0, 2.0, -1.0]),
+        A=np.array([1.0, -2.0, 1.0]),
+        B=np.array([-1.0, -3.0, 1.0]),
+    )
+
+    # Equivalent system LSF is min(G, max(A, B)).
+    np.testing.assert_allclose(result, np.array([1.0, -2.0, -1.0]))
+    assert [component.name for component in system.components] == [
+        "main",
+        "backup_a",
+        "backup_b",
+    ]
+
+
+def test_cut_set_system_matches_boolean_cut_sets():
+    components = {
+        name: ra.Component(name, lambda var=name, **kwargs: kwargs[var])
+        for name in ("E1", "E2", "E3", "E4", "E5")
+    }
+    system = ra.CutSetSystem(
+        [["E1", "E2"], ["E3", "E4"], ["E3", "E5"]],
+        components=components,
+    )
+
+    failed = {
+        "E1": np.array([False, True, True, False]),
+        "E2": np.array([False, True, False, True]),
+        "E3": np.array([True, False, True, True]),
+        "E4": np.array([False, False, True, False]),
+        "E5": np.array([False, False, False, True]),
+    }
+    values = {name: np.where(mask, -1.0, 1.0) for name, mask in failed.items()}
+
+    expected = (
+        (failed["E1"] & failed["E2"])
+        | (failed["E3"] & failed["E4"])
+        | (failed["E3"] & failed["E5"])
+    )
+
+    np.testing.assert_array_equal(system.failure_mask(**values), expected)
+    assert set(system.component_values(**values)) == set(components)
+
+
+def test_tie_set_system_matches_boolean_tie_sets():
+    components = {
+        name: ra.Component(name, lambda var=name, **kwargs: kwargs[var])
+        for name in ("A", "B", "C", "D")
+    }
+    system = ra.TieSetSystem([["A", "B"], ["C", "D"]], components=components)
+
+    safe = {
+        "A": np.array([True, True, False, False]),
+        "B": np.array([True, False, True, False]),
+        "C": np.array([False, True, True, False]),
+        "D": np.array([False, True, False, True]),
+    }
+    values = {name: np.where(mask, 1.0, -1.0) for name, mask in safe.items()}
+
+    expected_failure = ~((safe["A"] & safe["B"]) | (safe["C"] & safe["D"]))
+
+    np.testing.assert_array_equal(system.failure_mask(**values), expected_failure)
+
+
+def test_system_as_limit_state_integrates_with_pystra_evaluation():
+    system = ra.SeriesSystem(
+        [
+            ra.Component("flexure", lambda R, S: R - S),
+            ra.Component("shear", lambda V, S: V - 2.0 * S),
+        ]
+    )
+    limit_state = system.as_limit_state()
+
+    model = ra.StochasticModel()
+    model.addVariable(ra.Normal("R", 10.0, 1.0))
+    model.addVariable(ra.Normal("V", 12.0, 1.0))
+    model.addVariable(ra.Normal("S", 4.0, 1.0))
+
+    options = ra.AnalysisOptions()
+    options.setPrintOutput(False)
+
+    x = np.array(
+        [
+            [10.0, 10.0],
+            [12.0, 6.0],
+            [4.0, 4.0],
+        ]
+    )
+    values, gradient = limit_state.evaluate_lsf(x, model, options, diff_mode="no")
+
+    np.testing.assert_allclose(values, np.array([[4.0, -2.0]]))
+    assert gradient.shape == x.shape
+
+
+def test_system_limit_state_runs_form_analysis():
+    system = ra.SeriesSystem(
+        [
+            ra.Component("flexure", lambda R, S: R - S),
+            ra.Component("shear", lambda V, S: V - 2.0 * S),
+        ]
+    )
+
+    model = ra.StochasticModel()
+    model.addVariable(ra.Normal("R", 10.0, 1.0))
+    model.addVariable(ra.Normal("V", 12.0, 1.0))
+    model.addVariable(ra.Normal("S", 4.0, 1.0))
+
+    options = ra.AnalysisOptions()
+    options.setPrintOutput(False)
+
+    form = ra.Form(
+        stochastic_model=model,
+        limit_state=system.as_limit_state(),
+        analysis_options=options,
+    )
+    form.run()
+
+    assert np.isfinite(form.getBeta())
+    assert np.all(form.getFailure() > 0.0)
+
+
+def test_component_values_and_failure_masks():
+    system = ra.SeriesSystem(
+        [
+            ra.Component("a", lambda A: A),
+            ra.Component("b", lambda B: B),
+        ]
+    )
+
+    values = system.component_values(
+        A=np.array([1.0, -1.0]),
+        B=np.array([-2.0, 3.0]),
+    )
+    masks = system.component_failure_masks(
+        A=np.array([1.0, -1.0]),
+        B=np.array([-2.0, 3.0]),
+    )
+
+    np.testing.assert_allclose(values["a"], np.array([1.0, -1.0]))
+    np.testing.assert_allclose(values["b"], np.array([-2.0, 3.0]))
+    np.testing.assert_array_equal(masks["a"], np.array([False, True]))
+    np.testing.assert_array_equal(masks["b"], np.array([True, False]))
+
+
+def test_duplicate_component_names_are_rejected_for_component_value_mapping():
+    system = ra.SeriesSystem(
+        [
+            ra.Component("member", lambda A: A),
+            ra.Component("member", lambda B: B),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Duplicate component name"):
+        system.component_values(A=np.array([1.0]), B=np.array([2.0]))
+
+
+def test_ditlevsen_bounds_are_exact_for_two_events():
+    lower, upper = ra.ditlevsen_bounds(
+        [0.1, 0.2],
+        {(0, 1): 0.03},
+    )
+
+    assert lower == pytest.approx(0.27)
+    assert upper == pytest.approx(0.27)
+
+
+def test_ditlevsen_upper_bound_matches_maincon_identical_series_benchmark():
+    n_events = 100
+    component_probability = 1.969e-3
+    pair_probability = 1.361e-3
+    probabilities = np.full(n_events, component_probability)
+    intersections = np.full((n_events, n_events), pair_probability)
+    np.fill_diagonal(intersections, component_probability)
+
+    lower, upper = ra.ditlevsen_bounds(probabilities, intersections)
+
+    assert lower == pytest.approx(2.577e-3)
+    assert upper == pytest.approx(6.2161e-2)
+
+
+def test_ditlevsen_bounds_can_optimize_event_ordering():
+    probabilities = np.array([0.08, 0.07, 0.06])
+    intersections = np.array(
+        [
+            [0.08, 0.03, 0.01],
+            [0.03, 0.07, 0.02],
+            [0.01, 0.02, 0.06],
+        ]
+    )
+
+    lower, upper = ra.ditlevsen_bounds(
+        probabilities,
+        intersections,
+        optimize_order=True,
+    )
+
+    assert lower == pytest.approx(0.15)
+    assert upper == pytest.approx(0.16)
+
+
+def test_empty_system_raises():
+    with pytest.raises(ValueError, match="at least one child"):
+        ra.SeriesSystem([])


### PR DESCRIPTION
## Summary

  Adds a system reliability topology layer to Pystra: composes named component limit states into nested series, parallel, k-of-n, cut-set, and tie-set systems, and provides
  `ditlevsen_bounds` for second-order bounds from component event probabilities and pairwise intersections. Topology only — the resulting equivalent limit state is passed to existing
  Pystra algorithms (FORM/SORM/MCS/line sampling/subset simulation).

  ## Changes

  ### New module
  - `src/pystra/system.py` (+516) — `Component`, `System`, `SeriesSystem`, `ParallelSystem`, `KofNSystem`, `CutSetSystem`, `TieSetSystem`, `ditlevsen_bounds`.
  - `src/pystra/__init__.py` — export new public API.

  ### Tests
  - `tests/test_system.py` (+317) — coverage of series/parallel/k-of-n/cut-set/tie-set composition, nesting, kwarg filtering, and Ditlevsen bounds.

  ### Docs
  - New `docs/source/system.rst` (scope, sign convention, usage).
  - New `docs/source/notebooks/ex_system_reliability.ipynb` tutorial.
  - Theory section added to `theory.rst` (+168) with classical benchmark references in `references.rst`.
  - `api.rst`, `tutorial.rst`, `changelog.rst` updated.