### PR TITLE
Demote internal modules from public namespace

### DIFF
--- a/src/pystra/__init__.py
+++ b/src/pystra/__init__.py
@@ -35,17 +35,10 @@ __version__ = "1.6.0"
 
 # Distributions
 from .distributions import *
-from .correlation import *
+from .correlation import CorrelationMatrix
 
 # Inputparameter
 from .model import *
-
-# Calculations
-from .quadrature import *
-from .integration import *
-
-# Transformation
-from .transformation import *
 
 # Analysis
 from .analysis import *

--- a/src/pystra/analysis.py
+++ b/src/pystra/analysis.py
@@ -10,6 +10,8 @@ from .model import StochasticModel, LimitState
 from .transformation import Transformation
 from .correlation import setModifiedCorrelationMatrix
 
+__all__ = ["AnalysisObject", "AnalysisOptions"]
+
 
 class AnalysisObject:
     """Base class for reliability analysis objects (FORM, SORM, MC).

--- a/src/pystra/correlation.py
+++ b/src/pystra/correlation.py
@@ -19,7 +19,7 @@ from .integration import zi_and_xi, rho_integral
 class CorrelationMatrix:
     r"""Physical-space correlation matrix wrapper.
 
-    A thin wrapper around a NumPy array that stores the correlation
+    A wrapper around a NumPy array that stores the correlation
     matrix of :math:`n` random variables :math:`X_1, \dots, X_n`.
     The :math:`(i, j)` entry is :math:`\text{corr}(X_i, X_j)`.
 

--- a/src/pystra/form.py
+++ b/src/pystra/form.py
@@ -6,6 +6,8 @@ from scipy.stats import norm as normal
 from .analysis import AnalysisObject
 from .correlation import setModifiedCorrelationMatrix
 
+__all__ = ["Form"]
+
 
 class Form(AnalysisObject):
     r"""First Order Reliability Method (FORM)

--- a/src/pystra/mc.py
+++ b/src/pystra/mc.py
@@ -8,6 +8,8 @@ from .distributions import StdNormal
 from .correlation import computeModifiedCorrelationMatrix
 from .form import Form
 
+__all__ = ["MonteCarlo", "CrudeMonteCarlo", "ImportanceSampling", "DistributionAnalysis"]
+
 
 class MonteCarlo(AnalysisObject):
     r"""Monte Carlo Simulation

--- a/src/pystra/model.py
+++ b/src/pystra/model.py
@@ -136,7 +136,9 @@ class StochasticModel:
         self._marg = marg
 
     def setCorrelation(self, obj):
-        self._correlation = np.array(obj.getMatrix())
+        if hasattr(obj, "getMatrix"):
+            obj = obj.getMatrix()
+        self._correlation = np.asarray(obj)
 
     def getCorrelation(self):
         return self._correlation

--- a/src/pystra/sensitivity.py
+++ b/src/pystra/sensitivity.py
@@ -26,6 +26,8 @@ from .integration import zi_and_xi, drho_drho0, drho0_dtheta
 import copy
 import numpy as np
 
+__all__ = ["SensitivityAnalysis"]
+
 
 class SensitivityAnalysis:
     r"""Sensitivity analysis for the FORM reliability index.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -235,6 +235,16 @@ class TestCorrelationMatrix:
         r = repr(C)
         assert "1.0" in r
 
+    def test_setCorrelation_accepts_wrapper(self):
+        """setCorrelation accepts a CorrelationMatrix wrapper."""
+        model = ra.model.StochasticModel()
+        model.addVariable(Normal("X1", 10, 2))
+        model.addVariable(Normal("X2", 5, 1))
+        model.setCorrelation(CorrelationMatrix([[1.0, 0.5], [0.5, 1.0]]))
+        np.testing.assert_array_equal(
+            model.getCorrelation(), np.array([[1.0, 0.5], [0.5, 1.0]])
+        )
+
     def test_modified_correlation_uncorrelated_normals(self):
         """For uncorrelated normals, modified correlation should be identity."""
         model = ra.model.StochasticModel()


### PR DESCRIPTION
## Summary

- Remove `transformation`, `integration`, `quadrature`, and the `correlation` helpers (`computeModifiedCorrelationMatrix`, `setModifiedCorrelationMatrix`, `absoluteIntegralValue`) from the top-level `pystra.*` namespace. These are FORM/SORM/Nataf machinery and were never user-facing — the submodules remain importable as `pystra.transformation` etc. for the few who need them (tests already use the qualified path).
- Add `__all__` to `analysis`, `form`, `mc`, `sensitivity` so star-imports in `__init__.py` no longer leak the demoted symbols back onto the public surface.
- Make `StochasticModel.setCorrelation` accept array-likes directly (via `np.asarray`), with duck-typed back-compat for `CorrelationMatrix`. `CorrelationMatrix` remains the canonical wrapper surface — earmarked to grow Cholesky / PD validation / Nataf hooks in v2.0.

Public surface after this PR: distributions, `CorrelationMatrix`, `StochasticModel`, `LimitState`, `Form`, `Sorm`, `MonteCarlo`/`CrudeMonteCarlo`/`ImportanceSampling`/`DistributionAnalysis`, `LineSampling`, `SubsetSimulation`, `SensitivityAnalysis`, `FBCProcess` etc., `LoadCombination`, `Calibration`/`GenericModel`/`GenericCalibration`, `AnalysisObject`/`AnalysisOptions`.

## Test plan

- [x] Full test suite passes (316 tests, 9 pre-existing warnings).
- [x] `pystra.transformation`, `pystra.correlation`, `pystra.integration`, `pystra.quadrature` still importable as submodules.
- [x] `model.setCorrelation([[...]])` works (new permissive path).
- [x] `model.setCorrelation(CorrelationMatrix([[...]]))` still works (back-compat).
- [x] No top-level leak of `Transformation`, `quadratureRule`, `rho_integral`, `zi_and_xi`, `drho_drho0`, `drho0_dtheta`, `computeModifiedCorrelationMatrix`, `setModifiedCorrelationMatrix`, `absoluteIntegralValue`.
- [ ] Manual smoke-test of one example script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)