### PR TITLE
Add component-based system FORM reliability analysis

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,6 +21,7 @@ Core Framework
     pystra.model
     pystra.analysis
     pystra.system
+    pystra.system_form
 
 Reliability Methods
 -------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,8 @@ Unreleased
 
 Added
 ~~~~~
+- ``SystemFORM`` for component-based series/parallel reliability, joint normal
+  probabilities, component diagnostics and bounds on the linearized event.
 - ``pystra.system`` module for composing named component limit states into
   nested series, parallel, k-of-n, cut-set, and tie-set system limit states.
 - ``pystra.ditlevsen_bounds`` for second-order bounds from component event
@@ -19,6 +21,14 @@ Added
   transformations.
 - System reliability tutorial notebook and theory content with classical
   benchmark references.
+
+Fixed
+~~~~~
+- Component limit-state adapters now filter unused shared-model variables.
+- FORM distinguishes convergence from iteration exhaustion and rejects invalid
+  or zero gradients. Nonconverged runs warn and have ``results_valid=False``.
+- Ditlevsen bounds reject missing pairs, nonfinite inputs and intersections
+  inconsistent with marginal probabilities.
 
 v1.6.0 (2026-03-16)
 --------------------

--- a/docs/source/notebooks/ex_system_reliability.ipynb
+++ b/docs/source/notebooks/ex_system_reliability.ipynb
@@ -417,6 +417,76 @@
    "source": [
     "These bounds are deliberately separate from the topology classes. A topology tells Pystra which samples fail; Ditlevsen bounds require marginal and pairwise event probabilities, usually obtained from component analyses, simulation, or reference data."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Component-based system FORM and original-system Monte Carlo\n",
+    "\n",
+    "`SystemFORM` runs each component separately in the same complete stochastic model. It supports series and parallel events, including homogeneous nesting. Mixed and cut/tie-set systems use original-system simulation for now.\n",
+    "\n",
+    "The four-branch tangent-plane probability is about 0.00539, whereas the nonlinear event probability is about 0.00446. The difference is FORM approximation error, not sampling error. Bounds reported here apply to the tangent-plane events only.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "model = ra.StochasticModel()\n",
+    "model.addVariable(ra.Normal(\"X1\", 0.0, 1.0))\n",
+    "model.addVariable(ra.Normal(\"X2\", 0.0, 1.0))\n",
+    "\n",
+    "system_form = ra.SystemFORM(four_branch, model)\n",
+    "system_form.run()\n",
+    "print(\"System FORM:\", system_form.getFailure())\n",
+    "print(\"Linearized-event bounds:\", system_form.bounds)\n",
+    "print(\"Original nonlinear event (earlier simulation):\", pf_hat)\n",
+    "print(\"Component betas:\", system_form.betas)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For an exact check, two independent components with beta = 2 give series probability `2*p - p*p` and parallel probability `p*p`. Monte Carlo below evaluates the original series event. Its CoV reports sampling uncertainty; the sample budget is a maximum and the run may stop early at the target CoV. No observed failures would require more sampling, not a claim of zero risk.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from scipy.stats import norm\n",
+    "\n",
+    "linear_model = ra.StochasticModel()\n",
+    "linear_model.addVariable(ra.Normal(\"X\", 0.0, 1.0))\n",
+    "linear_model.addVariable(ra.Normal(\"Y\", 0.0, 1.0))\n",
+    "linear_components = [ra.Component(\"a\", lambda X: 2.0-X),\n",
+    "                     ra.Component(\"b\", lambda Y: 2.0-Y)]\n",
+    "series = ra.SeriesSystem(linear_components)\n",
+    "p = norm.sf(2.0)\n",
+    "for topology, exact in [(series, 2*p-p*p),\n",
+    "                        (ra.ParallelSystem(linear_components), p*p)]:\n",
+    "    result = ra.SystemFORM(topology, linear_model)\n",
+    "    result.run()\n",
+    "    print(topology.name, result.getFailure(), \"exact:\", exact)\n",
+    "    np.testing.assert_allclose(result.getFailure(), exact, rtol=1e-6)\n",
+    "\n",
+    "options = ra.AnalysisOptions()\n",
+    "options.setSamples(20_000)\n",
+    "options.setPrintOutput(False)\n",
+    "np.random.seed(2026)\n",
+    "mc = ra.CrudeMonteCarlo(stochastic_model=linear_model,\n",
+    "                       limit_state=series.as_limit_state(),\n",
+    "                       analysis_options=options)\n",
+    "mc.run()\n",
+    "print(\"Monte Carlo:\", mc.getFailure(), \"CoV:\", mc.cov_q_bar[mc.k-1],\n",
+    "      \"samples:\", mc.k)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/docs/source/system.rst
+++ b/docs/source/system.rst
@@ -4,12 +4,14 @@
 System Reliability
 ******************
 
-Pystra supports simple structural system composition through the
-``pystra.system`` module.  The module does not introduce a separate
-probability approximation method.  It builds an equivalent scalar
-limit-state function from named component limit states, and that function can
-then be used with the existing FORM, SORM, Monte Carlo, line sampling, subset
-simulation workflows.
+Pystra separates the system failure event from its probability calculation.
+The ``pystra.system`` topology classes compose component limit states for
+simulation. ``SystemFORM`` estimates series and parallel probabilities from
+separate component FORM analyses in one shared standard-normal space.
+
+Do not use ordinary FORM or SORM on the combined min/max function as a general
+system reliability method. One tangent plane can miss other failure regions,
+and ties can give misleading or zero finite-difference gradients.
 
 The sign convention is the usual Pystra convention: positive values are safe
 and negative values indicate failure.
@@ -36,8 +38,8 @@ without enumerating every failure path manually.  This includes common branch
 system benchmarks such as the :ref:`four-branch series example
 <ref-schueremans-2005>`.
 
-Example
-=======
+Original-system Monte Carlo
+===========================
 
 .. code-block:: python
 
@@ -66,12 +68,97 @@ Example
    model.addVariable(ra.Normal("A", 1.0, 0.5))
    model.addVariable(ra.Normal("B", 1.0, 0.5))
 
-   form = ra.Form(stochastic_model=model, limit_state=limit_state)
-   form.run()
+   import numpy as np
+
+   options = ra.AnalysisOptions()
+   options.setSamples(100_000)  # maximum budget; may stop at target CoV
+   options.setPrintOutput(False)
+   np.random.seed(2026)
+   mc = ra.CrudeMonteCarlo(
+       stochastic_model=model, limit_state=limit_state,
+       analysis_options=options,
+   )
+   mc.run()
+   print(mc.getFailure(), mc.cov_q_bar[mc.k - 1], mc.k)
+
+Monte Carlo evaluates the original nonlinear failure event, including mixed
+and cut/tie-set topologies. The reported CoV describes sampling uncertainty.
+Zero observed failures do not establish a zero failure probability: increase
+the sample budget or use a validated rare-event method. The legacy Monte Carlo
+beta value is not meaningful when no failures are observed.
 
 Component functions may use only the stochastic variables they need.  Extra
 model variables are filtered at the component boundary, which keeps small
 component functions reusable inside larger systems.
+
+Component-based system FORM
+===========================
+
+.. code-block:: python
+
+   from scipy.stats import norm
+
+   model = ra.StochasticModel()
+   model.addVariable(ra.Normal("X", 0.0, 1.0))
+   model.addVariable(ra.Normal("Y", 0.0, 1.0))
+   components = [
+       ra.Component("a", lambda X: 3.0 - X),
+       ra.Component("b", lambda Y: 3.0 - Y),
+   ]
+   analysis = ra.SystemFORM(ra.SeriesSystem(components), model)
+   analysis.run()
+   print(analysis.getFailure())  # approximately 0.002697974
+   print(analysis.getBeta())     # equivalent system index
+   print(analysis.bounds)        # Ditlevsen bounds on the linearized event
+   print(analysis.correlation)   # correlations of normal scores
+   print(analysis.component_results["a"].getDesignPoint())
+
+   p = norm.sf(3.0)
+   assert abs(analysis.getFailure() - (2*p - p*p)) < 1e-10
+
+Use ``ParallelSystem(components)`` for joint failure; the exact result in this
+example is ``p*p``. Homogeneous nesting is flattened and shared component
+objects are analysed once. Component names must be unique. Mixed topology,
+k-of-n and cut/tie-set inputs are currently rejected by ``SystemFORM``; use
+original-system simulation for these events.
+
+For each component, FORM finds a tangent failure half-space in the same
+independent standard-normal coordinates:
+
+.. math::
+
+   F_i \approx \{\alpha_i^T U > \beta_i\},
+   \qquad R_{ij}=\alpha_i^T\alpha_j.
+
+This includes dependence caused by shared variables and the Nataf input
+correlation model. ``correlation`` is the correlation of the linearized normal
+scores, not of the physical variables or binary failure indicators. All
+components retain the full model variable order. DDM functions must return
+gradients in that full order, including zeros for unused variables.
+
+``component_results`` retains the individual ``Form`` objects, including
+``converged``, ``e1`` and ``e2`` diagnostics. A failed component analysis raises
+an error and leaves the system result invalid. Ordinary ``Form`` now warns
+when it exhausts its iterations, and marks ``results_valid`` false.
+
+Series probabilities are integrated as disjoint first-failure events, avoiding
+subtraction of an almost-unit survival probability. Parallel probabilities
+use the joint normal failure event. Singular component correlation matrices
+are supported. ``maxpts``, ``abseps`` and ``releps`` control integration effort
+and requested tolerances; they do not certify numerical accuracy in rare
+multivariate tails. Bivariate integration uses relative-tolerance quadrature.
+Check sensitivity to tighter tolerances for demanding problems.
+
+Series results include Ditlevsen bounds and ``intersections``. Parallel results
+include the marginal/Frechet bounds. These bounds apply to the linearized
+events, with numerically evaluated probabilities. They are not guaranteed
+bounds on the original nonlinear system. Component FORM may also find a local
+design point; convergence alone does not establish global accuracy.
+
+The method is exact up to integration error for affine limit states in
+standard-normal space. For nonlinear components, compare with original-system
+simulation. The four-branch notebook illustrates the difference between the
+first-order approximation and the nonlinear event probability.
 
 Event Topologies
 ================
@@ -118,10 +205,12 @@ This can be represented directly from named components:
        components=components,
    )
 
-Event-counting and cut/tie-set systems preserve the correct failure sign for
-simulation, subset simulation, and Boolean enumeration.  They are not generally
-smooth limit-state functions, so FORM/SORM results should be interpreted with
-care unless the topology reduces to a smooth min/max envelope.
+These topologies preserve the failure sign for direct Monte Carlo and Boolean
+enumeration. The current k-of-n performance function is a discrete count;
+its plateaus make it unsuitable as a general subset-simulation performance
+measure. Existing line sampling assumes one failure tail per line, and existing
+importance sampling uses one FORM design point. Neither should be assumed to
+cover arbitrary system failure regions.
 
 Ditlevsen Bounds
 ================
@@ -130,7 +219,10 @@ When component event probabilities and pairwise intersection probabilities are
 available, :func:`pystra.ditlevsen_bounds` computes :ref:`Ditlevsen's
 second-order bounds <ref-ditlevsen-1979>` for a union of failure
 events.  The event ordering can be supplied explicitly, or exhaustively
-optimized for small systems.
+optimized for small systems. Every pair must be supplied (explicit zero for
+disjoint events); nonfinite values and violations of marginal/Frechet bounds
+are rejected. These checks do not prove global consistency of all supplied
+probabilities.
 
 .. code-block:: python
 
@@ -156,22 +248,21 @@ responsibility of the selected Pystra analysis method and its
 transformation, following the same conceptual split used in structural
 reliability methods generally.
 
-This first implementation deliberately avoids first-order system reliability
-method approximations and automatic failure-path enumeration.  Those methods
-can be useful, but they need additional assumptions about the component
-design points, dependence model, and transformation ordering.  In particular,
-Rosenblatt-based first-order system approximations can be sensitive to the
-conditioning order used for the transformation [Meinen2025]_.  For now,
-simulation methods can estimate the probability of failure from the composed
-system limit-state function directly.
+``SystemFORM`` uses Pystra's existing Nataf transformation, with the same
+factorisation choice for every component. Automatic failure-path enumeration,
+load redistribution and importance sampling around multiple design points
+remain future extensions.
 
 Validation Benchmarks
 =====================
 
 The current validation suite checks exact Boolean behaviour for series,
 parallel, k-of-n, cut-set, and tie-set systems; integration with Pystra's
-``LimitState`` evaluation; a FORM smoke test for smooth min/max systems; and
-Ditlevsen bounds for simple and published series-system cases.
+``LimitState`` evaluation; independent and correlated linear system
+probabilities; identical and opposing component directions; positive rescaling;
+shared components; failed FORM diagnostics; and Ditlevsen input validation.
+The legacy combined-limit-state FORM smoke test checks execution only, not
+system probability accuracy.
 
 The next benchmarks to add before extending the approximation methods are:
 

--- a/src/pystra/__init__.py
+++ b/src/pystra/__init__.py
@@ -50,6 +50,7 @@ from .ls import *
 from .ss import *
 from .sensitivity import *
 from .system import *
+from .system_form import *
 
 # Calibration
 from .fbc import *

--- a/src/pystra/form.py
+++ b/src/pystra/form.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import warnings
 from scipy.stats import norm as normal
 from .analysis import AnalysisObject
 from .correlation import setModifiedCorrelationMatrix
@@ -58,12 +59,25 @@ class Form(AnalysisObject):
         self.step = None
         self.beta = None
         self.Pf = None
+        self.converged = False
+        self.e1 = None
+        self.e2 = None
 
     def run(self):
         """
         Executes the FORM analysis
         """
-        self.results_valid = True
+        self.results_valid = False
+        self.converged = False
+        self.beta = self.Pf = None
+        self.i = self.e1 = self.e2 = None
+        imax = self.options.getImax()
+        if (
+            isinstance(imax, bool)
+            or not isinstance(imax, (int, np.integer))
+            or imax < 1
+        ):
+            raise ValueError("FORM iteration limit must be a positive integer")
 
         self.init_run()
 
@@ -91,6 +105,15 @@ class Form(AnalysisObject):
 
             # Evaluate limit-state function and its gradient
             self.computeLimitState()
+            if (
+                not np.all(np.isfinite(self.G))
+                or not np.all(np.isfinite(self.gradient))
+                or not np.isfinite(np.linalg.norm(self.gradient))
+                or np.linalg.norm(self.gradient) == 0
+            ):
+                raise ValueError(
+                    "FORM requires finite limit-state values and a nonzero finite gradient"
+                )
 
             # Set scale parameter Go and inform about struct. resp.
             if i == 1:
@@ -105,8 +128,10 @@ class Form(AnalysisObject):
             self.computeGamma()
 
             # Check convergence
-            e1 = np.absolute(self.G * self.Go ** (-1))[0]
+            scale = float(np.abs(self.Go).item()) or 1.0
+            e1 = float(np.abs(self.G).item()) / scale
             e2 = np.linalg.norm(self.u - self.alpha.dot(self.u).dot(self.alpha))
+            self.e1, self.e2 = e1, float(e2)
             condition1 = e1 < self.options.getE1()
             condition2 = e2 < self.options.getE2()
             condition3 = i == self.options.getImax()
@@ -115,6 +140,7 @@ class Form(AnalysisObject):
 
             if condition1 and condition2 or condition3:
                 self.i = i
+                self.converged = bool(condition1 and condition2)
                 convergence = True
 
             # space for some recording stuff
@@ -139,9 +165,14 @@ class Form(AnalysisObject):
 
         # Compute failure probability
         self.computeFailureProbability()
+        self.results_valid = self.converged
+        if not self.converged:
+            warnings.warn(
+                "FORM did not converge within the iteration limit", RuntimeWarning
+            )
 
         # Show Results
-        if self.options.getPrintOutput():
+        if self.options.getPrintOutput() and self.results_valid:
             self.showResults()
 
     def computeStartingPoint(self):

--- a/src/pystra/system.py
+++ b/src/pystra/system.py
@@ -1,9 +1,9 @@
 """System reliability limit-state composition.
 
 This module provides a small topology layer for structural system
-reliability.  It does not estimate system reliability directly.  Instead,
-it composes component limit-state functions into a single scalar limit-state
-function that can be passed to Pystra's existing reliability algorithms.
+reliability. It composes component functions into a scalar limit-state function
+for simulation. The separate SystemFORM class estimates series and parallel
+probabilities from component tangent planes.
 
 The sign convention is the standard Pystra convention: positive values are
 safe, and negative values indicate failure.  A series system fails when any
@@ -73,7 +73,11 @@ class Component:
     def as_limit_state(self):
         """Return this component as a Pystra :class:`LimitState`."""
 
-        return self.limit_state
+        # Keep tuple returns intact for direct differentiation. User-supplied
+        # gradients must follow the complete stochastic model variable order.
+        return LimitState(
+            lambda **kwargs: self.limit_state.expression(**self._filter_kwargs(kwargs))
+        )
 
     def getLimitState(self):
         """Return this component as a Pystra :class:`LimitState`.
@@ -185,8 +189,7 @@ class System:
         """Return failure masks for each leaf component."""
 
         return {
-            name: values < 0
-            for name, values in self.component_values(**kwargs).items()
+            name: values < 0 for name, values in self.component_values(**kwargs).items()
         }
 
     def failure_mask(self, **kwargs):
@@ -355,10 +358,18 @@ def ditlevsen_bounds(probabilities, intersections, ordering=None, optimize_order
         raise ValueError("probabilities must be a one-dimensional sequence")
     if len(probabilities) == 0:
         raise ValueError("At least one event probability is required")
-    if np.any((probabilities < 0.0) | (probabilities > 1.0)):
+    if not np.all(np.isfinite(probabilities)) or np.any(
+        (probabilities < 0.0) | (probabilities > 1.0)
+    ):
         raise ValueError("probabilities must be between 0 and 1")
 
     pairwise = _intersection_matrix(intersections, len(probabilities))
+    for i in range(len(probabilities)):
+        for j in range(i):
+            lo = max(0.0, probabilities[i] + probabilities[j] - 1.0)
+            hi = min(probabilities[i], probabilities[j])
+            if not lo - 1e-14 <= pairwise[i, j] <= hi + 1e-14:
+                raise ValueError("intersections violate marginal probability bounds")
 
     if optimize_order:
         if ordering is not None:
@@ -480,15 +491,23 @@ def _component_catalogue(components):
 def _intersection_matrix(intersections, n_events):
     if isinstance(intersections, dict):
         matrix = np.zeros((n_events, n_events), dtype=float)
+        for i in range(n_events):
+            for j in range(i):
+                if (i, j) not in intersections and (j, i) not in intersections:
+                    raise ValueError("Every pairwise intersection must be supplied")
         for key, value in intersections.items():
             i, j = key
+            if not (0 <= i < n_events and 0 <= j < n_events):
+                raise ValueError("Intersection index out of range")
+            if (j, i) in intersections and intersections[j, i] != value:
+                raise ValueError("intersections must be symmetric")
             matrix[i, j] = matrix[j, i] = float(value)
     else:
         matrix = np.asarray(intersections, dtype=float)
 
     if matrix.shape != (n_events, n_events):
         raise ValueError("intersections must be an n x n matrix or pair mapping")
-    if np.any((matrix < 0.0) | (matrix > 1.0)):
+    if not np.all(np.isfinite(matrix)) or np.any((matrix < 0.0) | (matrix > 1.0)):
         raise ValueError("intersections must be between 0 and 1")
     if not np.allclose(matrix, matrix.T):
         raise ValueError("intersections must be symmetric")
@@ -509,6 +528,8 @@ def _ditlevsen_bounds_for_order(probabilities, intersections, ordering):
         lower += max(probabilities[event] - np.sum(previous_intersections), 0.0)
         upper -= np.max(previous_intersections)
 
+    if lower > upper + 1e-12:
+        raise ValueError("Inconsistent probabilities produce reversed bounds")
     return _clip_probability(lower), _clip_probability(upper)
 
 

--- a/src/pystra/system_form.py
+++ b/src/pystra/system_form.py
@@ -1,0 +1,312 @@
+"""Component FORM approximation for series and parallel failure events."""
+
+from copy import copy
+
+import numpy as np
+from scipy.integrate import quad
+from scipy.stats import multivariate_normal, norm
+
+from .analysis import AnalysisObject
+from .form import Form
+from .system import Component, SeriesSystem, ParallelSystem, ditlevsen_bounds
+
+__all__ = ["SystemFORM"]
+
+
+class SystemFORM(AnalysisObject):
+    """Approximate a series or parallel system using component tangent planes.
+
+    All components use the same complete stochastic model and Nataf transform.
+    Homogeneous nested series/parallel systems are flattened; mixed topologies
+    are rejected. Use original-system Monte Carlo for general topologies.
+
+    Parameters
+    ----------
+    system : SeriesSystem or ParallelSystem
+        System failure event.
+    stochastic_model : StochasticModel
+        Shared variables, constants and dependence model.
+    analysis_options : AnalysisOptions, optional
+        Component FORM settings. DDM gradients must use full model ordering.
+    maxpts : int, optional
+        Maximum integration points per multivariate normal CDF call.
+    abseps, releps : float, optional
+        Requested absolute and relative integration tolerances. These are
+        numerical targets, not certified error bounds or FORM model errors.
+
+    Attributes
+    ----------
+    component_results : dict
+        Component names mapped to completed Form objects (beta, alpha,
+        design points and convergence residuals).
+    correlation : ndarray
+        Correlation of linearized normal scores, alpha @ alpha.T. This is
+        neither the physical-variable nor binary-failure correlation matrix.
+    bounds : tuple
+        Ditlevsen bounds for a series system; marginal/Frechet bounds for a
+        parallel system. These bound the linearized event only.
+    intersections : ndarray
+        Pairwise failure probabilities of the component tangent planes.
+
+    Notes
+    -----
+    Exact up to integration error for affine limit states in standard normal
+    space. Nonlinear components remain first-order approximations, and FORM
+    can find a local rather than global design point. Normal integration may
+    vary between runs; tight tolerances do not certify rare-tail accuracy.
+    """
+
+    def __init__(
+        self,
+        system,
+        stochastic_model,
+        analysis_options=None,
+        *,
+        maxpts=1000000,
+        abseps=1e-10,
+        releps=1e-5,
+    ):
+        if type(system) not in (SeriesSystem, ParallelSystem):
+            raise TypeError("SystemFORM requires a series or parallel system")
+        super().__init__(
+            stochastic_model=stochastic_model, analysis_options=analysis_options
+        )
+        self.system = system
+        leaves = []
+
+        def visit(node):
+            if isinstance(node, Component):
+                if all(node is not c for c in leaves):
+                    leaves.append(node)
+            elif type(node) is type(system):
+                for child in node.children:
+                    visit(child)
+            else:
+                raise TypeError(
+                    "Mixed system topology requires original-system simulation"
+                )
+
+        visit(system)
+        if len({c.name for c in leaves}) != len(leaves):
+            raise ValueError("SystemFORM requires unique component names")
+        if isinstance(maxpts, bool) or int(maxpts) != maxpts or maxpts < 1:
+            raise ValueError("maxpts must be a positive integer")
+        if not all(np.isfinite(t) and t > 0 for t in (abseps, releps)):
+            raise ValueError("Integration tolerances must be positive and finite")
+        self.components = tuple(leaves)
+        self.maxpts, self.abseps, self.releps = int(maxpts), abseps, releps
+        self._clear_results()
+
+    def _clear_results(self):
+        self.results_valid = False
+        self.component_results = {}
+        self.Pf = self.beta = self.bounds = None
+        self.betas = self.alphas = self.correlation = None
+        self.probabilities = self.intersections = None
+
+    def _cdf(self, upper, correlation):
+        for i in range(len(upper)):
+            for j in range(i):
+                if correlation[i, j] == -1 and upper[i] + upper[j] <= 0:
+                    return 0.0  # Proven empty event (up to a zero-mass boundary).
+        if len(upper) == 1:
+            return float(norm.cdf(upper[0]))
+        if np.array_equal(correlation, np.eye(len(upper))):
+            return float(np.prod(norm.cdf(upper)))
+        if np.all(np.abs(correlation[0]) == 1):
+            # Every score is the same normal variable, possibly negated.
+            positive = correlation[0] == 1
+            hi = float(np.min(upper[positive]))
+            lo = float(np.max(-upper[~positive])) if np.any(~positive) else -np.inf
+            if hi <= lo:
+                return 0.0
+            if lo > 0:
+                return float(norm.sf(lo) - norm.sf(hi))
+            return float(norm.cdf(hi) - norm.cdf(lo))
+        # Split independent score groups before integration. This also avoids
+        # unstable high-dimensional singular CDFs for opposing pairs along
+        # independent directions (e.g. the four-branch benchmark).
+        remaining = set(range(len(upper)))
+        groups = []
+        while remaining:
+            group = {remaining.pop()}
+            frontier = list(group)
+            while frontier:
+                i = frontier.pop()
+                neighbours = {
+                    j
+                    for j in remaining
+                    if abs(correlation[i, j]) > 8 * np.finfo(float).eps
+                }
+                remaining.difference_update(neighbours)
+                group.update(neighbours)
+                frontier.extend(neighbours)
+            groups.append(sorted(group))
+        if len(groups) > 1:
+            return float(
+                np.prod(
+                    [
+                        self._cdf(upper[ids], correlation[np.ix_(ids, ids)])
+                        for ids in groups
+                    ]
+                )
+            )
+        # Exact degeneracies avoid unstable bivariate integration at rho=+/-1.
+        if len(upper) == 2:
+            rho = correlation[0, 1]
+            if rho == 1.0:
+                return float(norm.cdf(min(upper)))
+            if rho == -1.0:
+                lo, hi = -upper[1], upper[0]
+                if hi <= lo:
+                    return 0.0
+                if lo > 0:
+                    return float(norm.sf(lo) - norm.sf(hi))
+                return float(norm.cdf(hi) - norm.cdf(lo))
+            # Integrate the conditional normal directly. Relative tolerance
+            # matters here: default absolute CDF tolerances can return zero
+            # for representable rare joint probabilities.
+            a, b = sorted(upper)
+            sigma = np.sqrt((1 - rho) * (1 + rho))
+            value, error = quad(
+                lambda x: norm.pdf(x) * norm.cdf((b - rho * x) / sigma),
+                -np.inf,
+                a,
+                epsabs=0,
+                epsrel=max(self.releps, 1e-12),
+                limit=200,
+            )
+            if error > max(self.abseps / len(self.components), self.releps * value):
+                raise RuntimeError(
+                    "Bivariate normal integration did not meet tolerance"
+                )
+            if value == 0:
+                raise RuntimeError(
+                    "Bivariate probability underflow or unresolved rare tail"
+                )
+            return float(value)
+        value = float(
+            multivariate_normal.cdf(
+                upper,
+                cov=correlation,
+                allow_singular=True,
+                maxpts=self.maxpts,
+                abseps=self.abseps / len(self.components),
+                releps=self.releps,
+            )
+        )
+        if not np.isfinite(value) or not 0 <= value <= 1:
+            raise RuntimeError("Normal probability integration failed")
+        if value == 0:
+            raise RuntimeError(
+                "Normal integration returned an unresolved zero probability"
+            )
+        return value
+
+    def run(self):
+        """Run each unique component once, then integrate the system event."""
+        self._clear_results()
+        options = copy(self.options)
+        options.setPrintOutput(False)
+        for component in self.components:
+            form = Form(
+                stochastic_model=self.model,
+                limit_state=component.as_limit_state(),
+                analysis_options=options,
+            )
+            self.component_results[component.name] = form
+            try:
+                form.run()
+            except (ValueError, FloatingPointError) as error:
+                raise RuntimeError(
+                    f"Component '{component.name}' FORM failed: {error}"
+                ) from error
+            if not form.converged or not np.isfinite(form.getBeta()):
+                raise RuntimeError(
+                    f"Component '{component.name}' FORM did not converge"
+                )
+
+        self.betas = np.array([f.getBeta() for f in self.component_results.values()])
+        self.alphas = np.array([f.getAlpha() for f in self.component_results.values()])
+        self.correlation = np.clip(self.alphas @ self.alphas.T, -1, 1)
+        np.fill_diagonal(self.correlation, 1.0)
+        # Recognize identical/opposing vectors at floating-point precision;
+        # their dot product can otherwise be one ulp short of +/-1.
+        for i, alpha in enumerate(self.alphas):
+            for j in range(i):
+                for sign in (-1, 1):
+                    if np.allclose(
+                        alpha,
+                        sign * self.alphas[j],
+                        rtol=0,
+                        atol=8 * np.finfo(float).eps,
+                    ):
+                        self.correlation[i, j] = self.correlation[j, i] = sign
+        self.probabilities = norm.sf(self.betas)
+        n = len(self.components)
+        pairwise = np.diag(self.probabilities)
+        for i in range(n):
+            for j in range(i):
+                ids = [i, j]
+                value = self._cdf(-self.betas[ids], self.correlation[np.ix_(ids, ids)])
+                lo = max(0.0, self.probabilities[i] + self.probabilities[j] - 1)
+                hi = min(self.probabilities[i], self.probabilities[j])
+                if value < lo - self.abseps or value > hi + self.abseps:
+                    raise RuntimeError("Pair probability violates marginal bounds")
+                pairwise[i, j] = pairwise[j, i] = np.clip(value, lo, hi)
+        self.intersections = pairwise
+
+        if isinstance(self.system, SeriesSystem):
+            order = np.argsort(-self.probabilities)
+            self.bounds = ditlevsen_bounds(self.probabilities, pairwise, ordering=order)
+            # Disjoint events: first failed component i, all previous safe.
+            # Avoid catastrophic cancellation in 1 - P(all safe).
+            pf = 0.0
+            for end in range(n):
+                ids = order[: end + 1]
+                signs = np.ones(end + 1)
+                signs[-1] = -1
+                covariance = self.correlation[np.ix_(ids, ids)] * np.outer(signs, signs)
+                pf += self._cdf(self.betas[ids] * signs, covariance)
+        else:
+            self.bounds = (
+                float(
+                    self.probabilities[0]
+                    if n == 1
+                    else max(0, self.probabilities.sum() - n + 1)
+                ),
+                float(self.probabilities.min()),
+            )
+            pf = self._cdf(-self.betas, self.correlation)
+        lo, hi = self.bounds
+        tolerance = self.abseps + self.releps * max(lo, abs(pf))
+        if not np.isfinite(pf) or pf < lo - tolerance or pf > hi + tolerance:
+            raise RuntimeError(
+                "System integration is inconsistent with probability bounds"
+            )
+        if pf == 0 and lo > 0:
+            raise RuntimeError(
+                "System probability underflow; increase integration accuracy"
+            )
+        self.Pf = float(np.clip(pf, 0, 1))
+        self.beta = float(-norm.ppf(self.Pf))
+        self.results_valid = True
+        if self.options.getPrintOutput():
+            self.showResults()
+
+    def getFailure(self):
+        """Return the system FORM probability after a successful run."""
+        if not self.results_valid:
+            raise ValueError("SystemFORM has no valid result")
+        return self.Pf
+
+    def getBeta(self):
+        """Return -Phi^-1(Pf), the equivalent system reliability index."""
+        self.getFailure()
+        return self.beta
+
+    def showResults(self):
+        """Print the approximation and bounds for its linearized event."""
+        print(f"System FORM Pf: {self.getFailure():.8g}")
+        print(f"Equivalent beta: {self.beta:.8g}")
+        print(f"Linearized-event bounds: {self.bounds}")

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -22,7 +22,7 @@ def test_component_accepts_limit_state_instance():
     limit_state = ra.LimitState(lambda R, S: R - S)
     component = ra.Component("member", limit_state)
 
-    assert component.as_limit_state() is limit_state
+    assert component.limit_state is limit_state
     np.testing.assert_allclose(
         component.evaluate(R=np.array([5.0]), S=np.array([3.0])),
         np.array([2.0]),

--- a/tests/test_system_form.py
+++ b/tests/test_system_form.py
@@ -1,0 +1,282 @@
+"""Analytical probability benchmarks for component-based system FORM."""
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+import pystra as ra
+
+
+def model2(rho=0):
+    model = ra.StochasticModel()
+    model.addVariable(ra.Normal("X", 0, 1))
+    model.addVariable(ra.Normal("Y", 0, 1))
+    model.setCorrelation([[1, rho], [rho, 1]])
+    return model
+
+
+@pytest.mark.parametrize("kind", [ra.SeriesSystem, ra.ParallelSystem])
+@pytest.mark.parametrize("beta", [2.0, 3.0, 8.0])
+def test_independent_exact(kind, beta):
+    system = kind(
+        [ra.Component("x", lambda X: beta - X), ra.Component("y", lambda Y: beta - Y)]
+    )
+    analysis = ra.SystemFORM(system, model2())
+    analysis.run()
+    p = norm.sf(beta)
+    exact = 2 * p - p * p if kind is ra.SeriesSystem else p * p
+    assert analysis.getFailure() == pytest.approx(exact, rel=1e-6, abs=0)
+    assert analysis.getBeta() == pytest.approx(-norm.ppf(exact), rel=1e-6)
+    np.testing.assert_allclose(analysis.correlation, np.eye(2), atol=1e-12)
+    assert all(f.converged for f in analysis.component_results.values())
+
+
+@pytest.mark.parametrize("kind", [ra.SeriesSystem, ra.ParallelSystem])
+@pytest.mark.parametrize("rho", [-0.7, 0.6])
+def test_correlated_orthant(kind, rho):
+    # P(X>0,Y>0) = 1/4 + asin(rho)/(2*pi).
+    system = kind([ra.Component("x", lambda X: -X), ra.Component("y", lambda Y: -Y)])
+    analysis = ra.SystemFORM(system, model2(rho))
+    analysis.run()
+    joint = 0.25 + np.arcsin(rho) / (2 * np.pi)
+    exact = 1 - joint if kind is ra.SeriesSystem else joint
+    assert analysis.getFailure() == pytest.approx(exact, abs=2e-7)
+    assert analysis.correlation[0, 1] == pytest.approx(rho)
+
+
+@pytest.mark.parametrize("kind", [ra.SeriesSystem, ra.ParallelSystem])
+@pytest.mark.parametrize("opposing", [False, True])
+def test_singular_component_directions(kind, opposing):
+    system = kind(
+        [
+            ra.Component("a", lambda X: 3 - X),
+            ra.Component("b", lambda X: 3 + X if opposing else 4 - X),
+        ]
+    )
+    analysis = ra.SystemFORM(system, model2())
+    analysis.run()
+    if opposing:
+        exact = 2 * norm.sf(3) if kind is ra.SeriesSystem else 0
+    else:
+        exact = norm.sf(3) if kind is ra.SeriesSystem else norm.sf(4)
+    assert analysis.getFailure() == pytest.approx(exact, abs=1e-12)
+
+
+def test_shared_components_nested_and_rescaling():
+    a = ra.Component("a", lambda X: 2 - X)
+    b = ra.Component("b", lambda X, Y: 3 - (X + Y) / np.sqrt(2))
+    s = ra.SeriesSystem([a, ra.SeriesSystem([a, b])])
+    baseline = ra.SystemFORM(s, model2())
+    baseline.run()
+    scaled = ra.SystemFORM(
+        ra.SeriesSystem(
+            [
+                ra.Component("a", lambda X: 1000 * (2 - X)),
+                ra.Component("b", lambda X, Y: 0.01 * (3 - (X + Y) / np.sqrt(2))),
+            ]
+        ),
+        model2(),
+    )
+    scaled.run()
+    assert len(baseline.component_results) == 2
+    assert baseline.getFailure() == pytest.approx(scaled.getFailure(), rel=1e-5)
+    assert baseline.correlation[0, 1] == pytest.approx(1 / np.sqrt(2))
+
+
+def test_single_component_and_full_order_ddm():
+    model = model2()
+    options = ra.AnalysisOptions()
+    options.setDiffMode("ddm")
+
+    def component(X):
+        return 3 - X, np.array([[-1.0], [0.0]])
+
+    analysis = ra.SystemFORM(
+        ra.SeriesSystem([ra.Component("a", component)]), model, options
+    )
+    analysis.run()
+    assert analysis.getFailure() == pytest.approx(norm.sf(3))
+
+
+def test_nonconvergence_invalidates_system_and_rerun():
+    options = ra.AnalysisOptions()
+    system = ra.SeriesSystem([ra.Component("a", lambda X: 3 - X)])
+    analysis = ra.SystemFORM(system, model2(), options)
+    analysis.run()
+    options.setImax(1)
+    with pytest.warns(RuntimeWarning, match="did not converge"):
+        with pytest.raises(RuntimeError, match="Component 'a'.*did not converge"):
+            analysis.run()
+    assert not analysis.results_valid
+    with pytest.raises(ValueError, match="no valid result"):
+        analysis.getFailure()
+
+
+def test_zero_gradient_rejected():
+    analysis = ra.SystemFORM(
+        ra.SeriesSystem([ra.Component("a", lambda X: X * 0 + 1)]), model2()
+    )
+    with pytest.raises(RuntimeError, match="nonzero finite gradient"):
+        analysis.run()
+    assert not analysis.results_valid
+
+
+def test_mixed_topology_rejected():
+    a = ra.Component("a", lambda X: X)
+    with pytest.raises(TypeError, match="Mixed"):
+        ra.SystemFORM(ra.SeriesSystem([ra.ParallelSystem([a])]), model2())
+
+
+@pytest.mark.parametrize(
+    "probabilities,intersections",
+    [
+        ([0.1, 0.2], {}),
+        ([0.1, 0.2], {(0, 1): 0.3}),
+        ([float("nan")], {}),
+        ([0.1, 0.2], {(0, 1): float("nan")}),
+        ([0.8, 0.8], {(0, 1): 0.1}),
+    ],
+)
+def test_invalid_bounds_inputs(probabilities, intersections):
+    with pytest.raises(ValueError):
+        ra.ditlevsen_bounds(probabilities, intersections)
+
+
+def test_four_branch_against_nonlinear_reference():
+    from scipy.integrate import quad
+
+    s2 = np.sqrt(2)
+    system = ra.SeriesSystem(
+        [
+            ra.Component("g1", lambda X, Y: 3 + 0.1 * (X - Y) ** 2 - (X + Y) / s2),
+            ra.Component("g2", lambda X, Y: 3 + 0.1 * (X - Y) ** 2 + (X + Y) / s2),
+            ra.Component("g3", lambda X, Y: X - Y + 6 / s2),
+            ra.Component("g4", lambda X, Y: Y - X + 6 / s2),
+        ]
+    )
+    analysis = ra.SystemFORM(system, model2())
+    analysis.run()
+    # Tangent planes give |U1|>3 or |U2|>3 after an orthogonal rotation.
+    p = norm.sf(3)
+    assert analysis.getFailure() == pytest.approx(4 * p - 4 * p * p, rel=2e-4)
+    reference = (
+        2 * p + quad(lambda v: norm.pdf(v) * 2 * norm.sf(3 + 0.2 * v * v), -3, 3)[0]
+    )
+    rng = np.random.default_rng(2026)
+    x, y = rng.standard_normal((2, 200000))
+    estimate = system.failure_mask(X=x, Y=y).mean()
+    se = np.sqrt(reference * (1 - reference) / len(x))
+    assert abs(estimate - reference) < 5 * se
+    # This nonlinear benchmark has genuine FORM model error.
+    assert 1.1 < analysis.getFailure() / reference < 1.3
+
+
+def test_original_cut_set_monte_carlo_shared_component():
+    model = model2()
+    model.addVariable(ra.Normal("Z", 0, 1))
+    components = {
+        "a": ra.Component("a", lambda X: 1 - X),
+        "b": ra.Component("b", lambda Y: 1 - Y),
+        "c": ra.Component("c", lambda Z: 1 - Z),
+    }
+    system = ra.CutSetSystem([["a", "b"], ["a", "c"]], components=components)
+    options = ra.AnalysisOptions()
+    options.setSamples(5000)
+    options.target_cov = 0
+    state = np.random.get_state()
+    try:
+        np.random.seed(2026)
+        mc = ra.CrudeMonteCarlo(
+            stochastic_model=model,
+            limit_state=system.as_limit_state(),
+            analysis_options=options,
+        )
+        mc.run()
+    finally:
+        np.random.set_state(state)
+    p = norm.sf(1)
+    exact = 2 * p * p - p**3
+    assert abs(mc.getFailure() - exact) < 5 * np.sqrt(exact * (1 - exact) / mc.k)
+    assert mc.cov_q_bar[mc.k - 1] > 0
+
+
+def test_nataf_factorisation_invariance_with_constants():
+    results = []
+    for factor in ["cholesky", "svd"]:
+        options = ra.AnalysisOptions()
+        options.setTransform(factor)
+        model = model2(0.4)
+        model.addVariable(ra.Constant("C", 2))
+        system = ra.SeriesSystem(
+            [
+                ra.Component("a", lambda X, C: C - X),
+                ra.Component("b", lambda X, Y: 3 - (X + Y)),
+            ]
+        )
+        analysis = ra.SystemFORM(system, model, options)
+        analysis.run()
+        results.append(analysis)
+    np.testing.assert_allclose(
+        results[0].correlation, results[1].correlation, atol=1e-10
+    )
+    assert results[0].getFailure() == pytest.approx(results[1].getFailure(), rel=1e-7)
+
+
+def test_unresolved_multivariate_zero_is_not_reported_as_safe(monkeypatch):
+    model = model2(0.3)
+    model.addVariable(ra.Normal("Z", 0, 1))
+    model.setCorrelation([[1, 0.3, 0.3], [0.3, 1, 0.3], [0.3, 0.3, 1]])
+    system = ra.ParallelSystem(
+        [
+            ra.Component("a", lambda X: 3 - X),
+            ra.Component("b", lambda Y: 3 - Y),
+            ra.Component("c", lambda Z: 3 - Z),
+        ]
+    )
+    monkeypatch.setattr(
+        "pystra.system_form.multivariate_normal.cdf", lambda *a, **kw: 0.0
+    )
+    analysis = ra.SystemFORM(system, model)
+    with pytest.raises(RuntimeError, match="unresolved zero"):
+        analysis.run()
+    assert not analysis.results_valid
+
+
+def test_single_rare_parallel_bounds_are_exact():
+    result = ra.SystemFORM(
+        ra.ParallelSystem([ra.Component("a", lambda X: 8 - X)]), model2()
+    )
+    result.run()
+    assert result.bounds == (result.getFailure(), result.getFailure())
+
+
+@pytest.mark.parametrize(
+    "kind,exact", [(ra.SeriesSystem, 0.75), (ra.ParallelSystem, 0.25)]
+)
+def test_three_correlated_normal_orthant(kind, exact):
+    model = model2()
+    model.addVariable(ra.Normal("Z", 0, 1))
+    model.setCorrelation([[1, 0.5, 0.5], [0.5, 1, 0.5], [0.5, 0.5, 1]])
+    system = kind(
+        [
+            ra.Component("a", lambda X: -X),
+            ra.Component("b", lambda Y: -Y),
+            ra.Component("c", lambda Z: -Z),
+        ]
+    )
+    result = ra.SystemFORM(system, model)
+    result.run()
+    # Trivariate zero-threshold orthant: 1/8 + sum(asin(rho_ij))/(4*pi).
+    assert result.getFailure() == pytest.approx(exact, abs=2e-6)
+
+
+def test_three_identical_directions():
+    system = ra.ParallelSystem(
+        [
+            ra.Component("a", lambda X: 2 - X),
+            ra.Component("b", lambda X: 3 - X),
+            ra.Component("c", lambda X: 4 - X),
+        ]
+    )
+    result = ra.SystemFORM(system, model2())
+    result.run()
+    assert result.getFailure() == pytest.approx(norm.sf(4), rel=1e-8, abs=0)


### PR DESCRIPTION
A series or parallel system can have several failure regions, which a single FORM tangent to its combined min/max limit state cannot represent. `SystemFORM` runs component FORM analyses in a shared standard-normal space and integrates their dependent tangent half-spaces.

- Computes series/parallel probabilities, retains component diagnostics, and reports Ditlevsen or marginal/Frechet bounds on the linearized event.
- Handles shared variables, identical/opposing directions, and singular component-score correlation matrices. Series integration avoids cancellation for small probabilities.
- Rejects unsupported mixed topology and failed component analyses. FORM now reports convergence failure explicitly; component adapters filter unused variables and Ditlevsen inputs receive consistency checks.
- Includes system reliability documentation and tutorial examples. The existing topology helpers remain available for original-event simulation.

Validation: 381 tests pass on this branch, including exact normal half-space systems and the nonlinear four-branch comparison. These are first-order approximations and bounds on the tangent events, not guaranteed bounds on the original nonlinear system.

First PR in the stack: **#94 → #95 (Strong Maximum Test) → #96 (joint distributions)**. Merge in that order; retarget each dependent PR to main after its base is merged.
