### PR TITLE
Reject nonconverged FORM results in SORM

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,9 @@ Added
 
 Fixed
 ~~~~~
+- SORM rejects unrun or nonconverged FORM analyses before curve-fitting or
+  point-fitting. Failed retries clear previous SORM output, and results become
+  valid only after fitting completes.
 - Component limit-state adapters now filter unused shared-model variables.
 - FORM distinguishes convergence from iteration exhaustion and rejects invalid
   or zero gradients. Nonconverged runs warn and have ``results_valid=False``.

--- a/src/pystra/sorm.py
+++ b/src/pystra/sorm.py
@@ -39,6 +39,12 @@ class Sorm(AnalysisObject):
         Options controlling the analysis.
     form : Form, optional
         A pre-computed FORM result. If ``None``, FORM is run automatically.
+        SORM requires a successfully converged FORM analysis before running.
+
+    Notes
+    -----
+    Result attributes are ``None`` before analysis and are cleared when a new
+    run begins. ``results_valid`` becomes ``True`` only after fitting completes.
 
     Attributes
     ----------
@@ -87,14 +93,27 @@ class Sorm(AnalysisObject):
         else:
             self.form = form
 
-        self.betaHL = 0
-        self.kappa = 0
+        self._reset_results()
+
+    def _reset_results(self):
+        """Invalidate previous SORM output before attempting another run."""
+        self.results_valid = False
+        self.betaHL = None
+        self.kappa = None
         self.kappa_pf = None
         self.fit_type = None
-        self.pf2_breitung = 0
-        self.betag_breitung = 0
-        self.pf2_breitung_m = 0
-        self.betag_breitung_m = 0
+        self.pf2_breitung = None
+        self.betag_breitung = None
+        self.pf2_breitung_m = None
+        self.betag_breitung_m = None
+
+    def _prepare_run(self, fit_type):
+        """Require a valid FORM design point before preparing either fit."""
+        self._reset_results()
+        if not self.form.results_valid or not self.form.converged:
+            raise RuntimeError("SORM requires a successfully converged FORM analysis")
+        self.init_run()
+        self.fit_type = fit_type
 
     def run(self, fit_type="cf"):
         """Run SORM analysis.
@@ -112,25 +131,23 @@ class Sorm(AnalysisObject):
         ------
         ValueError
             If *fit_type* is not ``'cf'`` or ``'pf'``.
+        RuntimeError
+            If the FORM analysis has not run or did not converge successfully.
         """
-        self.results_valid = True
-        self.init_run()
-        self.fit_type = fit_type
-
         if fit_type == "cf":
             self.run_curvefit()
         elif fit_type == "pf":
             self.run_pointfit()
         else:
+            self._reset_results()
             raise ValueError(
                 f"Unknown fit_type '{fit_type}'. Use 'cf' (curve-fitting) "
                 f"or 'pf' (point-fitting)."
             )
 
     def run_curvefit(self):
-        """
-        Run SORM analysis using curve fitting
-        """
+        """Run curve-fitting; require a successfully converged FORM analysis."""
+        self._prepare_run("cf")
         hess_G = self.computeHessian()
         R1 = self.orthonormal_matrix()
         A = R1 @ hess_G @ R1.T / np.linalg.norm(self.form.gradient)
@@ -140,6 +157,7 @@ class Sorm(AnalysisObject):
         self.kappa = np.sort(kappa)
         self.pf_breitung(self.betaHL, self.kappa)
         self.pf_breitung_m(self.betaHL, self.kappa)
+        self.results_valid = True
         if self.options.getPrintOutput():
             self.showResults()
 
@@ -168,7 +186,14 @@ class Sorm(AnalysisObject):
         See Also
         --------
         run_curvefit : Alternative SORM approach using Hessian eigenvalues.
+
+        Raises
+        ------
+        RuntimeError
+            If the FORM analysis has not run or did not converge successfully,
+            or a fitting point cannot be found.
         """
+        self._prepare_run("pf")
         beta = self.form.getBeta()
         nrv = self.form.alpha.shape[1]
         R1 = self.orthonormal_matrix()
@@ -199,6 +224,7 @@ class Sorm(AnalysisObject):
         self._pf_breitung_pf(beta, kappa_minus, kappa_plus)
         self._pf_breitung_m_pf(beta, kappa_minus, kappa_plus)
 
+        self.results_valid = True
         if self.options.getPrintOutput():
             self.showResults()
 
@@ -425,15 +451,11 @@ class Sorm(AnalysisObject):
         print("=" * n_hyphen)
         print("{:15s} \t\t {:1.10e}".format("Pf FORM", pfFORM))
         print("{:15s} \t\t {:1.10e}".format("Pf SORM Breitung", self.pf2_breitung))
-        print(
-            "{:15s} \t {:1.10e}".format("Pf SORM Breitung HR", self.pf2_breitung_m)
-        )
+        print("{:15s} \t {:1.10e}".format("Pf SORM Breitung HR", self.pf2_breitung_m))
         print("{:15s} \t\t {:2.10f}".format("Beta_HL", betaHL))
         print("{:15s} \t\t {:2.10f}".format("Beta_G Breitung", self.betag_breitung))
         print(
-            "{:15s} \t\t {:2.10f}".format(
-                "Beta_G Breitung HR", self.betag_breitung_m
-            )
+            "{:15s} \t\t {:2.10f}".format("Beta_G Breitung HR", self.betag_breitung_m)
         )
         print(
             "{:15s} \t\t {:d}".format("Model Evaluations", self.model.getCallFunction())

--- a/tests/test_sorm.py
+++ b/tests/test_sorm.py
@@ -1,0 +1,133 @@
+"""SORM must use a converged FORM design point for either fitting method."""
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+import pystra as ra
+
+
+@pytest.fixture
+def linear_problem():
+    model = ra.StochasticModel()
+    model.addVariable(ra.Normal("X", 0, 1))
+    model.addVariable(ra.Normal("Y", 0, 1))
+    return model, ra.LimitState(lambda X, Y: 5 - X - Y), ra.AnalysisOptions()
+
+
+def assert_invalid(analysis):
+    assert not analysis.results_valid
+    assert analysis.betaHL is None
+    assert analysis.kappa is None
+    assert analysis.kappa_pf is None
+    assert analysis.pf2_breitung is None
+    assert analysis.betag_breitung is None
+    assert analysis.pf2_breitung_m is None
+    assert analysis.betag_breitung_m is None
+    for report in (analysis.showResults, analysis.showDetailedOutput):
+        with pytest.raises(ValueError, match="Analysis not yet run"):
+            report()
+
+
+@pytest.mark.parametrize("fit_type", ["cf", "pf"])
+def test_sorm_rejects_automatically_run_nonconverged_form(linear_problem, fit_type):
+    model, limit_state, options = linear_problem
+    options.setImax(1)
+    with pytest.warns(RuntimeWarning, match="FORM did not converge"):
+        analysis = ra.Sorm(model, limit_state, options)
+
+    assert not analysis.form.converged
+    calls = model.getCallFunction()
+    with pytest.raises(RuntimeError, match="successfully converged FORM"):
+        analysis.run(fit_type)
+
+    assert model.getCallFunction() == calls
+    assert_invalid(analysis)
+
+
+@pytest.mark.parametrize("fit_type", ["cf", "pf"])
+@pytest.mark.parametrize("run_form", [False, True])
+def test_sorm_rejects_supplied_invalid_form(linear_problem, fit_type, run_form):
+    model, limit_state, options = linear_problem
+    options.setImax(1)
+    form = ra.Form(model, limit_state, options)
+    if run_form:
+        with pytest.warns(RuntimeWarning, match="FORM did not converge"):
+            form.run()
+    analysis = ra.Sorm(model, limit_state, options, form=form)
+
+    with pytest.raises(RuntimeError, match="successfully converged FORM"):
+        analysis.run(fit_type)
+    assert_invalid(analysis)
+
+
+@pytest.mark.parametrize("fit_type", ["cf", "pf"])
+def test_sorm_failed_form_rerun_clears_results_and_can_recover(
+    linear_problem, fit_type
+):
+    model, limit_state, options = linear_problem
+    analysis = ra.Sorm(model, limit_state, options)
+    analysis.run(fit_type)
+    expected_beta = 5 / np.sqrt(2)
+    expected_pf = norm.sf(expected_beta)
+    assert analysis.results_valid
+    assert analysis.pf2_breitung == pytest.approx(expected_pf, rel=1e-6)
+
+    options.setImax(1)
+    with pytest.warns(RuntimeWarning, match="FORM did not converge"):
+        analysis.form.run()
+    with pytest.raises(RuntimeError, match="successfully converged FORM"):
+        analysis.run(fit_type)
+    assert_invalid(analysis)
+
+    options.setImax(100)
+    analysis.form.run()
+    analysis.run(fit_type)
+    assert analysis.results_valid
+    assert analysis.betag_breitung == pytest.approx(expected_beta, rel=1e-6)
+    assert analysis.pf2_breitung == pytest.approx(expected_pf, rel=1e-6)
+    assert analysis.pf2_breitung_m == pytest.approx(expected_pf, rel=1e-6)
+
+
+@pytest.mark.parametrize("method", ["run_curvefit", "run_pointfit"])
+def test_direct_fitting_methods_check_form_and_preserve_reporting(
+    linear_problem, method, capsys
+):
+    model, limit_state, options = linear_problem
+    analysis = ra.Sorm(model, limit_state, options)
+    options.setPrintOutput(True)
+    getattr(analysis, method)()
+    assert analysis.results_valid
+    assert "SECOND ORDER RELIABILITY METHOD" in capsys.readouterr().out
+
+    options.setPrintOutput(False)
+    options.setImax(1)
+    with pytest.warns(RuntimeWarning, match="FORM did not converge"):
+        analysis.form.run()
+    with pytest.raises(RuntimeError, match="successfully converged FORM"):
+        getattr(analysis, method)()
+    assert_invalid(analysis)
+
+
+def test_invalid_fit_type_invalidates_previous_results(linear_problem):
+    model, limit_state, options = linear_problem
+    analysis = ra.Sorm(model, limit_state, options)
+    analysis.run()
+    with pytest.raises(ValueError, match="Unknown fit_type"):
+        analysis.run("invalid")
+    assert_invalid(analysis)
+
+
+@pytest.mark.parametrize("fit_type", ["cf", "pf"])
+def test_fitting_exception_does_not_leave_valid_results(linear_problem, fit_type):
+    model, limit_state, options = linear_problem
+    analysis = ra.Sorm(model, limit_state, options)
+    analysis.run()
+
+    def failed_evaluation(X, Y):
+        raise RuntimeError("External solver failed")
+
+    limit_state.setExpression(failed_evaluation)
+    with pytest.raises(RuntimeError, match="External solver failed"):
+        analysis.run(fit_type)
+    assert_invalid(analysis)


### PR DESCRIPTION
SORM currently proceeds with an unrun or nonconverged FORM analysis. For independent standard-normal X and Y with g = 5 - X - Y, limiting FORM to one iteration makes curve-fitting report a valid failure probability of 0.5 instead of the analytic 0.000203476. Point-fitting proceeds into invalid arithmetic before failing.

Both fitting entry points now require `form.results_valid` and `form.converged`, raising `RuntimeError` before any further limit-state evaluations if either is false. Each attempt clears previous SORM outputs, and `results_valid` becomes true only after fitting completes. This also prevents failed retries from exposing stale successful results. Unavailable result attributes are now `None` rather than placeholder zeros.

Targets `main` for the current 1.6 development line, using the FORM convergence metadata already merged in #94. Existing API names and successful numerical calculations are retained; no package version bump is included.

Validation:

- `PYTHONPATH=src python -m pytest -q`: **394 passed**, with nine existing calibration deprecation warnings.
- 13 new cases cover automatic and supplied FORM analyses, both fitting methods, unrun/failed prerequisites, retries and recovery, direct fitting entry points, reporting, invalid fit selection, and evaluation exceptions.
- The two automatic-FORM regression cases fail against the original implementation.
- Black checks pass for the changed Python files (Python 3.9 target).
- Sphinx HTML builds with warnings treated as errors, using saved notebook outputs. Notebook execution was not repeated; this change adds no notebook code.
